### PR TITLE
Running one end2end test

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,10 +9,12 @@ elifePipeline {
         builderProjectTests 'elife-metrics--ci', '/srv/elife-metrics' 
     }
 
-    stage 'Deploy on end2end'
+    stage 'End2end tests'
     lock('elife-metrics--end2end') {
-        builderDeployRevision 'elife-metrics--end2end', commit
-        builderSmokeTests 'elife-metrics--end2end', '/srv/elife-metrics'
+        elifeEnd2EndTest({
+            builderDeployRevision 'elife-metrics--end2end', commit
+            builderSmokeTests 'elife-metrics--end2end', '/srv/elife-metrics'
+        }, 'metrics')
     }
 
     elifeMainlineOnly {

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,15 +9,15 @@ elifePipeline {
         builderProjectTests 'elife-metrics--ci', '/srv/elife-metrics' 
     }
 
-    stage 'End2end tests'
-    lock('elife-metrics--end2end') {
-        elifeEnd2EndTest({
-            builderDeployRevision 'elife-metrics--end2end', commit
-            builderSmokeTests 'elife-metrics--end2end', '/srv/elife-metrics'
-        }, 'metrics')
-    }
-
     elifeMainlineOnly {
+        stage 'End2end tests'
+        lock('elife-metrics--end2end') {
+            elifeEnd2EndTest({
+                builderDeployRevision 'elife-metrics--end2end', commit
+                builderSmokeTests 'elife-metrics--end2end', '/srv/elife-metrics'
+            }, 'metrics')
+        }
+
         stage 'Approval'
         elifeGitMoveToBranch commit, 'approved'
     }

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,24 +1,29 @@
 elifePipeline {
-    stage 'Checkout'
-    checkout scm
-    def commit = elifeGitRevision()
+    def commit
+    stage 'Checkout', {
+        checkout scm
+        commit = elifeGitRevision()
+    }
 
-    stage 'Project tests'
-    lock('elife-metrics--ci') {
-        builderDeployRevision 'elife-metrics--ci', commit
-        builderProjectTests 'elife-metrics--ci', '/srv/elife-metrics' 
+    stage 'Project tests', {
+        lock('elife-metrics--ci') {
+            builderDeployRevision 'elife-metrics--ci', commit
+            builderProjectTests 'elife-metrics--ci', '/srv/elife-metrics' 
+        }
     }
 
     elifeMainlineOnly {
-        stage 'End2end tests'
-        lock('elife-metrics--end2end') {
-            elifeEnd2EndTest({
-                builderDeployRevision 'elife-metrics--end2end', commit
-                builderSmokeTests 'elife-metrics--end2end', '/srv/elife-metrics'
-            }, 'metrics')
+        stage 'End2end tests', {
+            lock('elife-metrics--end2end') {
+                elifeEnd2EndTest({
+                    builderDeployRevision 'elife-metrics--end2end', commit
+                    builderSmokeTests 'elife-metrics--end2end', '/srv/elife-metrics'
+                }, 'metrics')
+            }
         }
 
-        stage 'Approval'
-        elifeGitMoveToBranch commit, 'approved'
+        stage 'Approval', {
+            elifeGitMoveToBranch commit, 'approved'
+        }
     }
 }


### PR DESCRIPTION
So far the project got deployed into end2end, but didn't run any test to check whether there is a regression. We run the end2end tests tagged with `metrics`, which is just one test that published two versions of an article and tries to load them from the journal page to check that the metrics come up there without a 500 on the API