### PR TITLE
Log events sent to bus

### DIFF
--- a/src/metrics/events.py
+++ b/src/metrics/events.py
@@ -38,7 +38,7 @@ def notify(obj, **overrides):
             "metric": "citations" if isinstance(obj, models.Citation) else "views-downloads"
         }
         msg_json = json.dumps(msg)
-        LOG.debug("writing message to event bus", extra={'bus-message': msg_json})
+        LOG.info("writing message to event bus", extra={'bus-message': msg_json})
         event_bus_conn(**overrides).publish(Message=msg_json)
     except ValueError as err:
         # probably serializing value


### PR DESCRIPTION
We have no other logs of these, so it will be helpful in production to see what is being sent out