### PR TITLE
Using zero-padded article ids in events

### DIFF
--- a/src/metrics/events.py
+++ b/src/metrics/events.py
@@ -34,7 +34,7 @@ def notify(obj, **overrides):
         msg = {
             "type": "metrics",
             "contentType": "article",
-            "id": utils.doi2msid(obj.article.doi),
+            "id": utils.doi2articleid(obj.article.doi),
             "metric": "citations" if isinstance(obj, models.Citation) else "views-downloads"
         }
         msg_json = json.dumps(msg)

--- a/src/metrics/tests/test_events.py
+++ b/src/metrics/tests/test_events.py
@@ -1,7 +1,7 @@
 import json
 import base
 from mock import patch, Mock
-from metrics import models, logic, utils
+from metrics import models, logic
 from django.test import override_settings
 
 class One(base.TransactionBaseCase):
@@ -16,7 +16,7 @@ class One(base.TransactionBaseCase):
             'abstract': 0,
             'digest': 0,
             'pdf': 0,
-            'doi': utils.msid2doi(self.msid),
+            'doi': '10.7554/eLife.01234',
             'source': models.GA,
             'period': models.DAY,
             'date': '2001-01-01'
@@ -24,7 +24,7 @@ class One(base.TransactionBaseCase):
         expected_event = json.dumps({
             "type": "metrics",
             "contentType": "article",
-            "id": self.msid,
+            "id": "01234",
             "metric": "views-downloads"
         })
         mock = Mock()
@@ -36,7 +36,7 @@ class One(base.TransactionBaseCase):
     def test_new_citation_sends_article_update(self):
         self.msid = 1234
         citation_data = {
-            'doi': utils.msid2doi(self.msid),
+            'doi': '10.7554/eLife.01234',
             'num': 1,
             'source': models.CROSSREF,
             'source_id': 'pants-party'
@@ -44,7 +44,7 @@ class One(base.TransactionBaseCase):
         expected_event = json.dumps({
             "type": "metrics",
             "contentType": "article",
-            "id": self.msid,
+            "id": "01234",
             "metric": "citations"
         })
         mock = Mock()

--- a/src/metrics/tests/test_utils.py
+++ b/src/metrics/tests/test_utils.py
@@ -87,3 +87,11 @@ class TestUtils(base.BaseCase):
         ]
         for string, expected in cases:
             self.assertEqual(utils.todt(string), expected)
+
+    def test_doi_to_article_id_for_events(self):
+        self.assertEqual(utils.doi2articleid('10.7554/eLife.00003'), '00003')
+        self.assertEqual(utils.doi2articleid('10.7554/eLife.10627'), '10627')
+
+    def test_msid_to_doi(self):
+        self.assertEqual(utils.msid2doi(3), '10.7554/eLife.00003')
+        self.assertEqual(utils.msid2doi(10627), '10.7554/eLife.10627')

--- a/src/metrics/utils.py
+++ b/src/metrics/utils.py
@@ -78,11 +78,15 @@ def ensure(assertion, msg, *args):
     if not assertion:
         raise AssertionError(msg % args)
 
-def doi2msid(doi):
-    "doi to manuscript id used in EJP"
+def doi2articleid(doi):
+    "doi to article id sent by Lax"
     prefix = '10.7554/eLife.'
     ensure(doi.startswith(prefix), "this doesn't look like an eLife doi: %s" % prefix)
-    return int(doi[len(prefix):].lstrip('0'))
+    return doi[len(prefix):]
+
+def doi2msid(doi):
+    "doi to manuscript id used in EJP"
+    return int(doi2articleid(doi).lstrip('0'))
 
 def msid2doi(msid):
     assert isint(msid), "given msid must be an integer: %r" % msid


### PR DESCRIPTION
This is consistent with the events and the data produced by the Lax API:
```
$ curl prod--gateway.elifesciences.org/articles/3 | jq .id
"00003"
```