### PR TITLE
adds an /article/summary endpoint

### DIFF
--- a/src/metrics/api_v2_logic.py
+++ b/src/metrics/api_v2_logic.py
@@ -1,3 +1,4 @@
+from collections import OrderedDict
 import models
 import utils
 from utils import ensure, rest, lmap
@@ -8,6 +9,7 @@ def chop(q, page, per_page, order):
     total = q.count()
 
     order_by_idx = {
+        models.Article: 'doi',
         models.Metric: 'date',
         models.Citation: 'num',
     }
@@ -74,3 +76,24 @@ def article_views(msid, period):
     # convenience
     total_views, _, qobj = article_stats(msid, period)
     return total_views, qobj
+
+#
+#
+#
+
+def summary_by_msid(msid):
+    views, downloads, _ = article_stats(msid, models.DAY)
+    row = OrderedDict([
+        ('msid', msid),
+        ('views', views),
+        ('downloads', downloads),
+        (models.CROSSREF, 0),
+        (models.PUBMED, 0),
+        (models.SCOPUS, 0)
+    ])
+    _, qobj = article_citations(msid)
+    row.update(dict(map(lambda obj: (obj.source, obj.num), qobj.order_by('source'))))
+    return row
+
+def summary_by_obj(artobj):
+    return summary_by_msid(utils.doi2msid(artobj.doi))

--- a/src/metrics/api_v2_urls.py
+++ b/src/metrics/api_v2_urls.py
@@ -5,4 +5,8 @@ urlpatterns = [
     # article-level metrics
     url(r'^ping$', views.ping, name='ping'),
     url(r'^article/(?P<id>\d+)/(?P<metric>(citations|downloads|page-views))$', views.article_metrics, name='alm'),
+
+    #url(r'^article/summary/(?P<id>\d+)$', views.article_summary, name='article-summary'),
+    url(r'^article/summary$', views.summary, name='summary'),
+
 ]

--- a/src/metrics/api_v2_views.py
+++ b/src/metrics/api_v2_views.py
@@ -117,17 +117,25 @@ def article_metrics(request, id, metric):
         LOG.exception("unhandled exception attempting to serve article metrics: %s", err)
         raise # 500, server error
 
+#
+#
+#
+
 @api_view(['GET'])
 @renderer_classes((StaticHTMLRenderer,))
 def ping(request):
     "Returns a constant response for monitoring. Never to be cached."
     return Response('pong', content_type='text/plain; charset=UTF-8', headers={'Cache-Control': 'must-revalidate, no-cache, no-store, private'})
 
+#
+#
+#
+
 @api_view(['GET'])
 def summary(request):
+    "returns the final totals for all articles with no finer grained information"
     try:
         kwargs = request_args(request)
-        print kwargs
         qobj = models.Article.objects.all()
         total_results, qpage = logic.chop(qobj, **exsubdict(kwargs, ['period']))
         payload = map(logic.summary_by_obj, qpage)

--- a/src/metrics/tests/test_api_v2.py
+++ b/src/metrics/tests/test_api_v2.py
@@ -360,18 +360,13 @@ class Three(base.BaseCase):
             {'totalArticles': 3, 'summaries': [
                 {'msid': 1111, 'views': 1, 'downloads': 1, models.CROSSREF: 1, models.PUBMED: 1, models.SCOPUS: 1},
             ]},
-
-
             {'totalArticles': 3, 'summaries': [
                 {'msid': 2222, 'views': 2, 'downloads': 2, models.CROSSREF: 2, models.PUBMED: 2, models.SCOPUS: 2},
             ]},
-
             {'totalArticles': 3, 'summaries': [
                 {'msid': 3333, 'views': 3, 'downloads': 3, models.CROSSREF: 3, models.PUBMED: 3, models.SCOPUS: 3}
             ]},
-
         ]
-
         for page, expected_response in enumerate(page_cases):
             page += 1 # enumerate is zero-based
             url = reverse('v2:summary')


### PR DESCRIPTION
endpoint returns totals of multiple articles, rather than multiple periods of a single article.
there is room for per-article summaries as well.