### PR TITLE
fixed bug where bad doi caused 400 response in summary

### DIFF
--- a/src/metrics/api_v2_views.py
+++ b/src/metrics/api_v2_views.py
@@ -137,7 +137,11 @@ def summary(request, id=None):
     "returns the final totals for all articles with no finer grained information"
     try:
         kwargs = request_args(request)
-        qobj = models.Article.objects.all()
+        # TODO: we have a '10.7554/eLife.00000' in models.Article that needs deleting
+        #qobj = models.Article.objects.all()
+        qobj = models.Article.objects.all() \
+          .exclude(doi='10.7554/eLife.00000')
+
         if id:
             qobj = qobj.filter(doi=msid2doi(id))
 

--- a/src/metrics/tests/test_utils.py
+++ b/src/metrics/tests/test_utils.py
@@ -94,6 +94,16 @@ class TestUtils(base.BaseCase):
         for given, expected in cases:
             self.assertEqual(utils.doi2msid(given), expected)
 
+    def test_bad_doi_to_msid(self):
+        cases = [
+            '',
+            '10.7554/eLife.',
+            '10.7554/eLife.0',
+            '10.7554/eLife.0000000000000000000',
+        ]
+        for badegg in cases:
+            self.assertRaises(AssertionError, utils.doi2msid, badegg)
+
     def test_msid_to_doi(self):
         self.assertEqual(utils.msid2doi(3), '10.7554/eLife.00003')
         self.assertEqual(utils.msid2doi(10627), '10.7554/eLife.10627')

--- a/src/metrics/utils.py
+++ b/src/metrics/utils.py
@@ -94,10 +94,12 @@ def pad_msid(msid):
 def doi2msid(doi):
     "doi to manuscript id used in EJP"
     prefix = '10.7554/eLife.'
-    ensure(doi.startswith(prefix), "this doesn't look like an eLife doi: %s" % prefix)
+    ensure(doi.startswith(prefix), "unparseable eLife doi")
     stripped = doi[len(prefix):].lstrip('0')
+    stripped = stripped.split('.')[0]
+    ensure(isint(stripped), "unparseable eLife doi")
     # handles dois like: 10.7554/eLife.09560.001
-    return int(stripped.split('.')[0])
+    return int(stripped)
 
 def msid2doi(msid):
     assert isint(msid), "given msid must be an integer: %r" % msid


### PR DESCRIPTION
found two cases that could make it past the `doi2msid` function.