### PR TITLE
Bugfix: consistent summary keys

### DIFF
--- a/src/metrics/api_v2_logic.py
+++ b/src/metrics/api_v2_logic.py
@@ -84,7 +84,7 @@ def article_views(msid, period):
 def summary_by_msid(msid):
     views, downloads, _ = article_stats(msid, models.DAY)
     row = OrderedDict([
-        ('msid', msid),
+        ('id', msid),
         ('views', views),
         ('downloads', downloads),
         (models.CROSSREF, 0),

--- a/src/metrics/api_v2_logic.py
+++ b/src/metrics/api_v2_logic.py
@@ -19,7 +19,13 @@ def chop(q, page, per_page, order):
     if order == 'DESC':
         order_by = '-' + order_by
 
-    q = q.order_by(order_by)
+    more_sorting = {
+        models.Citation: lambda ob: (order_by, 'source'),
+    }
+    default = lambda ob: (order_by,)
+    order_by = more_sorting.get(q.model, default)(order_by)
+
+    q = q.order_by(*order_by)
 
     # a per-page = 0 means 'all results'
     if per_page > 0:
@@ -31,17 +37,22 @@ def chop(q, page, per_page, order):
 
 def pad_citations(serialized_citation_response):
     cr = serialized_citation_response
-    # TODO: bug here. pads will have the order of
-    # models.SOURCE_LABELS (alphabetical, asc) and not what the user specified
     missing_sources = set(models.SOURCE_LABELS) - set([cite['service'] for cite in cr])
-
+    if not missing_sources:
+        return cr
+    # WARN: thorny logic here
+    # results are sorted by number, but when there are no results for a service we pad
+    # with a zero result. when multiple citations have the same number, results are then
+    # sorted alphabetically by source (service).
     def pad(source):
         return {
             'service': source,
             'uri': '',
             'citations': 0
         }
-    return cr + lmap(pad, missing_sources)
+    pads = lmap(pad, missing_sources)
+    pads = sorted(pads, key=lambda r: r['service'])
+    return cr + pads
 
 #
 #

--- a/src/metrics/api_v2_views.py
+++ b/src/metrics/api_v2_views.py
@@ -153,8 +153,8 @@ def summary(request, id=None):
         payload = lmap(logic.summary_by_obj, qpage)
 
         payload = {
-            'totalArticles': total_results,
-            'summaries': payload
+            'total': total_results,
+            'items': payload
         }
         return Response(payload, content_type="application/json")
 

--- a/src/metrics/tests/test_api_v2.py
+++ b/src/metrics/tests/test_api_v2.py
@@ -311,7 +311,7 @@ class Three(base.BaseCase):
         expected_response = {
             'total': 1,
             'items': [{
-                'msid': 1234,
+                'id': 1234,
                 'views': 11,
                 'downloads': 10,
                 models.CROSSREF: 2,
@@ -338,9 +338,9 @@ class Three(base.BaseCase):
             'items': [
                 # default ordering per API is DESC
                 # default ordering key for articles is DOI
-                {'msid': 3333, 'views': 3, 'downloads': 3, models.CROSSREF: 3, models.PUBMED: 3, models.SCOPUS: 3},
-                {'msid': 2222, 'views': 2, 'downloads': 2, models.CROSSREF: 2, models.PUBMED: 2, models.SCOPUS: 2},
-                {'msid': 1111, 'views': 1, 'downloads': 1, models.CROSSREF: 1, models.PUBMED: 1, models.SCOPUS: 1},
+                {'id': 3333, 'views': 3, 'downloads': 3, models.CROSSREF: 3, models.PUBMED: 3, models.SCOPUS: 3},
+                {'id': 2222, 'views': 2, 'downloads': 2, models.CROSSREF: 2, models.PUBMED: 2, models.SCOPUS: 2},
+                {'id': 1111, 'views': 1, 'downloads': 1, models.CROSSREF: 1, models.PUBMED: 1, models.SCOPUS: 1},
             ]
         }
 
@@ -359,13 +359,13 @@ class Three(base.BaseCase):
 
         page_cases = [
             {'total': 3, 'items': [
-                {'msid': 1111, 'views': 1, 'downloads': 1, models.CROSSREF: 1, models.PUBMED: 1, models.SCOPUS: 1},
+                {'id': 1111, 'views': 1, 'downloads': 1, models.CROSSREF: 1, models.PUBMED: 1, models.SCOPUS: 1},
             ]},
             {'total': 3, 'items': [
-                {'msid': 2222, 'views': 2, 'downloads': 2, models.CROSSREF: 2, models.PUBMED: 2, models.SCOPUS: 2},
+                {'id': 2222, 'views': 2, 'downloads': 2, models.CROSSREF: 2, models.PUBMED: 2, models.SCOPUS: 2},
             ]},
             {'total': 3, 'items': [
-                {'msid': 3333, 'views': 3, 'downloads': 3, models.CROSSREF: 3, models.PUBMED: 3, models.SCOPUS: 3}
+                {'id': 3333, 'views': 3, 'downloads': 3, models.CROSSREF: 3, models.PUBMED: 3, models.SCOPUS: 3}
             ]},
         ]
         for page, expected_response in enumerate(page_cases):
@@ -392,7 +392,7 @@ class Three(base.BaseCase):
         expected_response = {
             'total': 1,
             'items': [
-                {'msid': 2222, 'views': 2, 'downloads': 2, models.CROSSREF: 2, models.PUBMED: 2, models.SCOPUS: 2},
+                {'id': 2222, 'views': 2, 'downloads': 2, models.CROSSREF: 2, models.PUBMED: 2, models.SCOPUS: 2},
             ]
         }
         self.assertEqual(resp.json(), expected_response)
@@ -419,7 +419,7 @@ class Four(base.BaseCase):
         expected_response = {
             'total': 1,
             'items': [{
-                'msid': 1234,
+                'id': 1234,
                 'views': 11,
                 'downloads': 10,
                 models.CROSSREF: 2,

--- a/src/metrics/tests/test_api_v2.py
+++ b/src/metrics/tests/test_api_v2.py
@@ -116,6 +116,7 @@ class ApiV2(base.BaseCase):
                 # json.loads(resp.bytes.decode('utf-8')) # python3
                 json.loads(resp.content.decode('utf-8'))
 
+    # WARN! non-deterministic results!
     def test_citations(self):
         cases = {
             '5678': (23, 0, 0)
@@ -291,8 +292,8 @@ class Three(base.BaseCase):
         self.assertEqual(resp.status_code, 200)
 
         expected_response = {
-            'totalArticles': 0,
-            'summaries': []
+            'total': 0,
+            'items': []
         }
         self.assertEqual(resp.json(), expected_response)
 
@@ -308,8 +309,8 @@ class Three(base.BaseCase):
         base.insert_metrics(cases)
 
         expected_response = {
-            'totalArticles': 1,
-            'summaries': [{
+            'total': 1,
+            'items': [{
                 'msid': 1234,
                 'views': 11,
                 'downloads': 10,
@@ -333,8 +334,8 @@ class Three(base.BaseCase):
         base.insert_metrics(cases)
 
         expected_response = {
-            'totalArticles': 3,
-            'summaries': [
+            'total': 3,
+            'items': [
                 # default ordering per API is DESC
                 # default ordering key for articles is DOI
                 {'msid': 3333, 'views': 3, 'downloads': 3, models.CROSSREF: 3, models.PUBMED: 3, models.SCOPUS: 3},
@@ -357,13 +358,13 @@ class Three(base.BaseCase):
         base.insert_metrics(cases)
 
         page_cases = [
-            {'totalArticles': 3, 'summaries': [
+            {'total': 3, 'items': [
                 {'msid': 1111, 'views': 1, 'downloads': 1, models.CROSSREF: 1, models.PUBMED: 1, models.SCOPUS: 1},
             ]},
-            {'totalArticles': 3, 'summaries': [
+            {'total': 3, 'items': [
                 {'msid': 2222, 'views': 2, 'downloads': 2, models.CROSSREF: 2, models.PUBMED: 2, models.SCOPUS: 2},
             ]},
-            {'totalArticles': 3, 'summaries': [
+            {'total': 3, 'items': [
                 {'msid': 3333, 'views': 3, 'downloads': 3, models.CROSSREF: 3, models.PUBMED: 3, models.SCOPUS: 3}
             ]},
         ]
@@ -389,8 +390,8 @@ class Three(base.BaseCase):
         # expect just one result
         resp = self.c.get(reverse('v2:summary'))
         expected_response = {
-            'totalArticles': 1,
-            'summaries': [
+            'total': 1,
+            'items': [
                 {'msid': 2222, 'views': 2, 'downloads': 2, models.CROSSREF: 2, models.PUBMED: 2, models.SCOPUS: 2},
             ]
         }
@@ -416,8 +417,8 @@ class Four(base.BaseCase):
         base.insert_metrics(cases)
 
         expected_response = {
-            'totalArticles': 1,
-            'summaries': [{
+            'total': 1,
+            'items': [{
                 'msid': 1234,
                 'views': 11,
                 'downloads': 10,


### PR DESCRIPTION
could be a prelude to getting the summary endpoint integrated into the api. for now, it's just another edge case observer doesn't have to deal with as more data is slurped from endpoints and stuck in the reporting database.

* depends on py3 PR being merged
* support in observer for new keys