### PR TITLE
fix: clears any pyc files during install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -26,6 +26,12 @@ if [ ! -e app.cfg ]; then
     echo "* no app.cfg found! using the example settings (elife.cfg) by default."
     ln -s elife.cfg app.cfg
 fi
+
+# remove any old compiled python files
+# pylint likes to lint them
+find src/ -name '*.py[c|~]' -delete
+find src/ -regex "\(.*__pycache__.*\|*.py[co]\)" -delete
+
 pip install -r requirements.txt
 python src/manage.py migrate --no-input
 

--- a/src/article_metrics/tests/test_pm_citations.py
+++ b/src/article_metrics/tests/test_pm_citations.py
@@ -82,15 +82,13 @@ class One(base.BaseCase):
         })
         art.save()
 
-        # TODO: this doesn't appear to actually be doing anything ...
-        # fixture = join(self.fixture_dir, 'pm-citation-request-response-09560.json')
-        # expected_body_content = json.load(open(fixture, 'r'))
-        # responses.add(responses.GET, citations.PM_URL, **{
-        #    'json': expected_body_content,
-        #    'status': 200,
-        #    'content_type': 'application/json'})
+        fixture = join(self.fixture_dir, 'pm-citation-request-response-09560.json')
+        expected_body_content = json.load(open(fixture, 'r'))
+        responses.add(responses.GET, citations.PM_URL, **{
+            'json': expected_body_content,
+            'status': 200,
+            'content_type': 'application/json'})
 
-        # TODO: and this is a lame test
         citations.citations_for_all_articles()
 
     @responses.activate


### PR DESCRIPTION
the Big Rename may be causing weirdness in pyc files.

also fixed a test I broke a while back. it breaks non-deterministicly.