### PR TITLE
fix: metric and citation rows with bad doi values will now be dropped.

### DIFF
--- a/src/article_metrics/ga_metrics/core.py
+++ b/src/article_metrics/ga_metrics/core.py
@@ -6,7 +6,7 @@
 
 from os.path import join
 import os, json, time, random
-from datetime import datetime, timedelta
+from datetime import datetime
 from googleapiclient import errors
 from googleapiclient.discovery import build
 from oauth2client.client import AccessTokenRefreshError
@@ -325,18 +325,3 @@ def article_metrics(table_id, from_date, to_date, cached=False, only_cached=Fals
 
     # keep the two separate until we introduce POAs? or just always
     return {'views': views, 'downloads': downloads}
-
-
-#
-# bootstrap
-#
-
-def main(table_id):
-    to_date = from_date = datetime.now() - timedelta(days=1)
-    # use cache if available. use cache exclusively if the client-secrets.json file not found
-    #use_cached, use_only_cached = True, not os.path.exists('client-secrets.json')
-    use_cached, use_only_cached = True, not oauth_secrets()
-    print(('cached?', use_cached))
-    print(('only cached?', use_only_cached))
-    #use_cached = use_only_cached = False
-    return article_metrics(table_id, from_date, to_date, use_cached, use_only_cached)

--- a/src/article_metrics/scopus/citations.py
+++ b/src/article_metrics/scopus/citations.py
@@ -1,7 +1,7 @@
 import requests
 import logging
 from django.conf import settings
-from article_metrics import models, handler
+from article_metrics import models, handler, utils
 from article_metrics.utils import first, flatten, simple_rate_limiter, lmap, lfilter, has_key, ParseError, ensure
 
 LOG = logging.getLogger(__name__)
@@ -86,19 +86,23 @@ def parse_entry(entry):
         citedby_link = first(lfilter(lambda d: d["@ref"] == "scopus-citedby", entry['link']))
         ensure('prism:doi' in entry, "entry is missing 'doi'!", ParseError)
         ensure('citedby-count' in entry, "entry is missing 'citedby-count'!", ParseError)
+        utils.doi2msid(entry['prism:doi'], allow_subresource=False) # throws AssertionError
 
-        # don't swallow these, bad values are different from bad structure
-        # we may be able to recover from a dodgy doi
-        ensure(entry['prism:doi'].startswith(settings.DOI_PREFIX), 'entry has an unknown DOI prefix: %r' % entry['prism:doi'])
         return {
             'doi': entry['prism:doi'],
             'num': int(entry['citedby-count']),
             'source': models.SCOPUS,
             'source_id': citedby_link['@href']
         }
+
+    # errors handled here won't be caught by handler.capture_parse_error
+
+    except AssertionError:
+        LOG.warn("discarding scopus citation: failed to parse doi", extra={'response': entry})
+        return {'bad': entry}
+
     except ParseError:
-        # these won't be caught by handler.capture_parse_error
-        LOG.warn("discarding scopus citation: failed to parse response", extra={'response': entry})
+        LOG.warn("discarding scopus citation: failed to parse entry", extra={'response': entry})
         return {'bad': entry}
 
 def parse_results(search_result):

--- a/src/article_metrics/tests/test_logic.py
+++ b/src/article_metrics/tests/test_logic.py
@@ -31,10 +31,13 @@ class One(BaseCase):
         fixture = scopus_citations.parse_results(search_results)
         with mock.patch("article_metrics.scopus.citations.all_todays_entries", return_value=fixture):
             logic.import_scopus_citations()
-            bad_eggs = 3
-            expected = len(fixture) - bad_eggs
-            self.assertEqual(expected, models.Article.objects.count())
 
+            unparseable_entries = 2
+            unknown_doi_prefixes = 1
+            subresource_dois = 2
+            bad_eggs = unparseable_entries + unknown_doi_prefixes + subresource_dois
+            expected = len(fixture) - bad_eggs
+            self.assertEqual(models.Article.objects.count(), expected)
 
 class TestGAImport(BaseCase):
     def setUp(self):
@@ -66,13 +69,13 @@ class TestGAImport(BaseCase):
             'digest': 0,
             'period': 'day',
             'date': '2001-01-01',
-            'doi': '10.7554/DUMMY',
+            'doi': '10.7554/elife.1',
             'source': models.GA,
         }
         logic.insert_row(ds1)
         self.assertEqual(1, models.Article.objects.count())
         self.assertEqual(1, models.Metric.objects.count())
-        clean_metric = models.Metric.objects.get(article__doi='10.7554/DUMMY')
+        clean_metric = models.Metric.objects.get(article__doi='10.7554/elife.1')
         self.assertEqual(0, clean_metric.pdf)
 
         expected_update = {
@@ -82,10 +85,10 @@ class TestGAImport(BaseCase):
             'digest': 0,
             'period': 'day',
             'date': '2001-01-01',
-            'doi': '10.7554/DUMMY',
+            'doi': '10.7554/elife.1',
             'source': models.GA,
         }
         logic.insert_row(expected_update)
         self.assertEqual(1, models.Metric.objects.count())
-        clean_metric = models.Metric.objects.get(article__doi='10.7554/DUMMY')
+        clean_metric = models.Metric.objects.get(article__doi='10.7554/elife.1')
         self.assertEqual(1, clean_metric.pdf)

--- a/src/article_metrics/utils.py
+++ b/src/article_metrics/utils.py
@@ -85,14 +85,17 @@ def ensure(assertion, msg, exception_class=AssertionError):
 def pad_msid(msid):
     return str(int(msid)).zfill(5)
 
-def doi2msid(doi):
+def doi2msid(doi, allow_subresource=True):
     "doi to manuscript id used in EJP"
     prefix = '10.7554/elife.'
-    ensure(doi.lower().startswith(prefix), "unparseable eLife doi (%sxxxxx)" % prefix)
+    ensure(doi.lower().startswith(prefix), "unparseable elife doi, unrecognised prefix")
     stripped = doi[len(prefix):].lstrip('0')
-    stripped = stripped.split('.')[0]
-    ensure(isint(stripped), "unparseable eLife doi")
     # handles dois like: 10.7554/eLife.09560.001
+    bits = stripped.split('.', 1)
+    if not allow_subresource:
+        ensure(len(bits) == 1, "refusing to parse elife doi further, subresource detected")
+    stripped = bits[0]
+    ensure(isint(stripped), "unparseable elife doi, manuscript ID is not an integer")
     return int(stripped)
 
 def msid2doi(msid):


### PR DESCRIPTION
ticket: https://elifesciences.atlassian.net/browse/ELPP-3605

scopus supports dropping these rows earlier as it's the only source that returns sub-resource dois.
changed behaviour where bad doi values are written to disk to be inspected. they are now logged and dropped.