### PR TITLE
Fix: further doi checks

### DIFF
--- a/src/article_metrics/pm/bulkload_pmids.py
+++ b/src/article_metrics/pm/bulkload_pmids.py
@@ -1,5 +1,5 @@
 """PMC provide a CSV of it's DB via FTP."""
-from article_metrics import models
+from article_metrics import models, utils
 from article_metrics.utils import create_or_update, lmap, ensure
 from django.conf import settings
 from django.db import transaction
@@ -17,6 +17,12 @@ def update_article(row):
     ensure(data['doi'].startswith(settings.DOI_PREFIX), "refusing to create/update non-journal article: %s" % row)
     if not data['pmid']:
         LOG.warn("no pmid for %s" % data['doi'])
+
+    # the doi values in the csv data look perfect and I've never had a problem with them
+    # however
+    # we only do it once per new production machine and it doesn't hurt to check
+    utils.doi2msid(data['doi'], allow_subresource=False)
+
     return create_or_update(models.Article, data, ['doi'], create=True, update=True, update_check=True)
 
 @transaction.atomic

--- a/src/article_metrics/pm/citations.py
+++ b/src/article_metrics/pm/citations.py
@@ -52,7 +52,7 @@ def _fetch_pmids(doi):
     # ]
     #}
     ensure(data['status'] == 'ok', "response is not ok! %s" % data)
-    return subdict(data['records'][0], ['doi', 'pmid', 'pmcid'])
+    return subdict(data['records'][0], ['pmid', 'pmcid'])
 
 def resolve_pmcid(artobj):
     pmcid = artobj.pmcid
@@ -60,13 +60,13 @@ def resolve_pmcid(artobj):
         LOG.debug("no pmcid fetch necessary")
         return pmcid
     data = _fetch_pmids(artobj.doi)
-    return first(utils.create_or_update(models.Article, data, ['doi'], create=False, update=True)).pmcid
+    data['doi'] = artobj.doi # don't use doi from response, prefer the doi we already have
+    artobj = first(utils.create_or_update(models.Article, data, ['doi'], create=False, update=True))
+    return artobj.pmcid
 
 #
 #
 #
-
-PM_URL = "https://eutils.ncbi.nlm.nih.gov/entrez/eutils/elink.fcgi"
 
 def fetch(pmcid_list):
     ensure(len(pmcid_list) <= MAX_PER_PAGE,

--- a/src/article_metrics/tests/test_pm_citations.py
+++ b/src/article_metrics/tests/test_pm_citations.py
@@ -33,7 +33,7 @@ class One(base.BaseCase):
             'content_type': 'application/json'})
 
         expected = {
-            'doi': '10.7554/eLife.09560',
+            # 'doi': '10.7554/eLife.09560', # removed from response, prefer the doi we already have
             'pmid': '26354291',
             'pmcid': 'PMC4559886'
         }


### PR DESCRIPTION
PR started off as an effort to centralise remaining `models.Article` modifications to avoid introducing bad DOI values, but one case rarely happens (bulkloading pmc ids) and the other case we can simply abstain from using the DOI value returned in favour of the one we already have.