### PR TITLE
fixed bug where mixed case 'elife' was slipping into data.

### DIFF
--- a/src/article_metrics/logic.py
+++ b/src/article_metrics/logic.py
@@ -61,7 +61,9 @@ def recently_updated_article_notifications(**kwargs):
 def get_create_article(data):
     "single point for accessing/creating Articles. returns None on bad data"
     try:
-        'doi' in data and utils.doi2msid(data['doi'], allow_subresource=False)
+        if 'doi' in data:
+            msid = utils.doi2msid(data['doi'], allow_subresource=False)
+            data['doi'] = utils.msid2doi(msid) # temporary, until doi field is replaced with msid field
         return first(create_or_update(models.Article, data, ['doi'], create=True, update=False))
     except AssertionError as err:
         # it shouldn't get to this point!

--- a/src/article_metrics/tests/test_logic.py
+++ b/src/article_metrics/tests/test_logic.py
@@ -39,6 +39,21 @@ class One(BaseCase):
             expected = len(fixture) - bad_eggs
             self.assertEqual(models.Article.objects.count(), expected)
 
+class Two(BaseCase):
+    def test_get_create_article(self):
+        "article is created if doesn't exist"
+        cases = [
+            {'doi': '10.7554/eLife.01234'},
+            {'doi': '10.7554/elife.01234'},
+            {'doi': '10.7554/ELIFE.01234'},
+        ]
+        self.assertEqual(models.Article.objects.count(), 0)
+        for row in cases:
+            artobj = logic.get_create_article(row)
+            self.assertEqual(artobj.doi, '10.7554/eLife.01234')
+        self.assertEqual(models.Article.objects.count(), 1)
+
+
 class TestGAImport(BaseCase):
     def setUp(self):
         pass
@@ -69,13 +84,13 @@ class TestGAImport(BaseCase):
             'digest': 0,
             'period': 'day',
             'date': '2001-01-01',
-            'doi': '10.7554/elife.1',
+            'doi': '10.7554/eLife.00001',
             'source': models.GA,
         }
         logic.insert_row(ds1)
         self.assertEqual(1, models.Article.objects.count())
         self.assertEqual(1, models.Metric.objects.count())
-        clean_metric = models.Metric.objects.get(article__doi='10.7554/elife.1')
+        clean_metric = models.Metric.objects.get(article__doi='10.7554/eLife.00001')
         self.assertEqual(0, clean_metric.pdf)
 
         expected_update = {
@@ -85,10 +100,10 @@ class TestGAImport(BaseCase):
             'digest': 0,
             'period': 'day',
             'date': '2001-01-01',
-            'doi': '10.7554/elife.1',
+            'doi': '10.7554/eLife.00001',
             'source': models.GA,
         }
         logic.insert_row(expected_update)
         self.assertEqual(1, models.Metric.objects.count())
-        clean_metric = models.Metric.objects.get(article__doi='10.7554/elife.1')
+        clean_metric = models.Metric.objects.get(article__doi='10.7554/eLife.00001')
         self.assertEqual(1, clean_metric.pdf)

--- a/src/article_metrics/utils.py
+++ b/src/article_metrics/utils.py
@@ -105,7 +105,7 @@ def doi2msid(doi, safe=False, allow_subresource=True):
         raise
 
 def msid2doi(msid):
-    assert isint(msid), "given msid must be an integer: %r" % msid
+    ensure(isint(msid), "given msid must be an integer: %r" % msid)
     return '10.7554/eLife.%05d' % int(msid)
 
 def subdict(d, kl):
@@ -179,9 +179,11 @@ def create_or_update(Model, orig_data, key_list=None, create=True, update=True, 
     data.update(orig_data)
     data.update(overrides)
     key_list = key_list or data.keys()
+    key_list = subdict(data, key_list)
     try:
         # try and find an entry of Model using the key fields in the given data
-        inst = Model.objects.get(**subdict(data, key_list))
+        ensure(keys, "refusing to fetch %s with empty keys: %s" % (str(Model), key_list))
+        inst = Model.objects.get(**key_list)
         # object exists, otherwise DoesNotExist would have been raised
 
         # test if objects needs updating


### PR DESCRIPTION
I think the `pmc_fetch_id` function was actually replacing bad internal doi's with their better ones... anyway, this ensures that while we're stuck using DOIs, their prefix is reconstituted before anything is created.