### PR TITLE
adds check for non-integer scopus citedby-count values

### DIFF
--- a/src/article_metrics/tests/fixtures/scopus-responses/dodgy-scopus-results.json
+++ b/src/article_metrics/tests/fixtures/scopus-responses/dodgy-scopus-results.json
@@ -1452,7 +1452,67 @@
             "prism:volume": "2013",
             "openaccess": "1",
             "prism:publicationName": "eLife"
-        }
+        },
+        {
+            "prism:doi": "10.7554/eLife.04550",
+            "pubmed-id": "25723966",
+            "prism:issueIdentifier": "4",
+            "subtypeDescription": "Article",
+            "affiliation": [
+              {
+                "affiliation-country": "United Kingdom",
+                "@_fa": "true",
+                "affilname": "The Sainsbury Laboratory",
+                "affiliation-city": "Norwich"
+              },
+              {
+                "affiliation-country": "United Kingdom",
+                "@_fa": "true",
+                "affilname": "Earlham Institute",
+                "affiliation-city": "Norwich"
+              }
+            ],
+            "prism:eIssn": "2050084X",
+            "openaccessFlag": true,
+            "link": [
+              {
+                "@href": "https://api.elsevier.com/content/abstract/scopus_id/85003042811",
+                "@ref": "self",
+                "@_fa": "true"
+              },
+              {
+                "@href": "https://api.elsevier.com/content/abstract/scopus_id/85003042811?field=author,affiliation",
+                "@ref": "author-affiliation",
+                "@_fa": "true"
+              },
+              {
+                "@href": "https://www.scopus.com/inward/record.uri?partnerID=HzOxMe3b&scp=85003042811&origin=inward",
+                "@ref": "scopus",
+                "@_fa": "true"
+              },
+              {
+                "@href": "https://www.scopus.com/inward/citedby.uri?partnerID=HzOxMe3b&scp=85003042811&origin=inward",
+                "@ref": "scopus-citedby",
+                "@_fa": "true"
+              }
+            ],
+            "prism:coverDate": "2015-02-27",
+            "citedby-count": "Heidelberg",
+            "prism:pageRange": null,
+            "dc:creator": "McMullan M.",
+            "dc:identifier": "SCOPUS_ID:85003042811",
+            "@_fa": "true",
+            "subtype": "ar",
+            "prism:aggregationType": "Journal",
+            "source-id": "21100242814",
+            "openaccess": "1",
+            "prism:url": "https://api.elsevier.com/content/abstract/scopus_id/85003042811",
+            "prism:publicationName": "eLife",
+            "eid": "2-s2.0-85003042811",
+            "dc:title": "Evidence for suppression of immunity as a driver for genomic introgressions and host range expansion in races of Albugo candida, a generalist parasite",
+            "prism:volume": "2015",
+            "prism:coverDisplayDate": "27 February 2015"
+      }
     ],
     "opensearch:Query": {
         "@searchTerms": "DOI(\"10.7554/*\")",

--- a/src/article_metrics/tests/test_logic.py
+++ b/src/article_metrics/tests/test_logic.py
@@ -32,7 +32,7 @@ class One(BaseCase):
         with mock.patch("article_metrics.scopus.citations.all_todays_entries", return_value=fixture):
             logic.import_scopus_citations()
 
-            unparseable_entries = 2
+            unparseable_entries = 3
             unknown_doi_prefixes = 1
             subresource_dois = 2
             bad_eggs = unparseable_entries + unknown_doi_prefixes + subresource_dois

--- a/src/article_metrics/tests/test_scopus_citations.py
+++ b/src/article_metrics/tests/test_scopus_citations.py
@@ -19,7 +19,10 @@ class One(base.BaseCase):
 
     def test_scopus_parse_entry(self):
         "citations.parse_entry can handle all known fixtures"
-        response_fixtures = utils.listfiles(join(self.fixture_dir, 'scopus-responses'))
+        response_fixtures = [
+            join(self.fixture_dir, 'scopus-responses/search-p1.json'),
+            join(self.fixture_dir, 'scopus-responses/search-p2.json')
+        ]
         response_fixtures = lmap(lambda path: json.load(open(path, 'r')), response_fixtures)
         res = citations.all_entries(response_fixtures)
         per_page = 25
@@ -85,10 +88,10 @@ class One(base.BaseCase):
         with patch('article_metrics.scopus.citations.fetch_page', side_effect=[response1, response2]):
             # we get something for all of our entries
             results = citations.all_todays_entries()
-            total_results = 25
+            total_results = 26
             self.assertEqual(len(results), total_results)
 
-            unparseable_entries = 2
+            unparseable_entries = 3
             unknown_doi_prefixes = 1
             subresource_dois = 2
             bad_eggs = unparseable_entries + unknown_doi_prefixes + subresource_dois


### PR DESCRIPTION
scopus has returned a result of 'Heidelburg' for the field 'citedby-count' in a standard response. This PR adds an integer check