### PR TITLE
fixes typo in utils.create_or_update allowing a check to be bypassed.

### DIFF
--- a/src/article_metrics/logic.py
+++ b/src/article_metrics/logic.py
@@ -64,7 +64,7 @@ def get_create_article(data):
         if 'doi' in data:
             msid = utils.doi2msid(data['doi'], allow_subresource=False)
             data['doi'] = utils.msid2doi(msid) # temporary, until doi field is replaced with msid field
-        return first(create_or_update(models.Article, data, ['doi'], create=True, update=False))
+        return first(create_or_update(models.Article, data, create=True, update=False))
     except AssertionError as err:
         # it shouldn't get to this point!
         LOG.warn("refusing to fetch/create bad article: %s" % err, extra={'article-data': data})

--- a/src/article_metrics/tests/test_logic.py
+++ b/src/article_metrics/tests/test_logic.py
@@ -53,6 +53,21 @@ class Two(BaseCase):
             self.assertEqual(artobj.doi, '10.7554/eLife.01234')
         self.assertEqual(models.Article.objects.count(), 1)
 
+    def test_get_create_article_no_doi(self):
+        "non-doi identifiers can be used"
+        # one perfect article
+        art1 = logic.get_create_article({'doi': '10.7554/eLife.01234', 'pmid': 1, 'pmcid': 2})
+        self.assertEqual(1, models.Article.objects.count())
+
+        # attempt to get/create same article
+        art2 = logic.get_create_article({'pmid': 1})
+        self.assertEqual(1, models.Article.objects.count())
+
+        art3 = logic.get_create_article({'pmcid': 2})
+        self.assertEqual(1, models.Article.objects.count())
+        
+        self.assertEqual(art1.id, art2.id)
+        self.assertEqual(art2.id, art3.id)
 
 class TestGAImport(BaseCase):
     def setUp(self):

--- a/src/article_metrics/tests/test_pm_citations.py
+++ b/src/article_metrics/tests/test_pm_citations.py
@@ -114,7 +114,7 @@ class One(base.BaseCase):
         self.assertEqual(results, expected)
 
     @responses.activate
-    def test_count_for_blah(self):
+    def test_count_response(self):
         art = models.Article(**{
             'doi': self.doi,
             'pmid': self.pmid,

--- a/src/article_metrics/tests/test_utils.py
+++ b/src/article_metrics/tests/test_utils.py
@@ -1,4 +1,4 @@
-from article_metrics import utils
+from article_metrics import utils, models
 from . import base
 import pytz
 from datetime import datetime
@@ -9,6 +9,16 @@ class TestUtils(base.BaseCase):
 
     def tearDown(self):
         pass
+
+    def test_create_or_update(self):
+        obj, created, updated = utils.create_or_update(models.Article, {'doi': '10.7554/eLife.1234'})
+        self.assertTrue(obj)
+        self.assertEqual(True, created)
+        self.assertEqual(False, updated)
+
+    def test_create_or_update_bad_keylist(self):
+        utils.create_or_update(models.Article, {'doi': '10.7554/eLife.1234', 'pmid': 1})
+        self.assertRaises(AssertionError, utils.create_or_update, models.Article, {'pmid': 1}, key_list=['???'])
 
     def test_isint(self):
         int_list = [

--- a/src/article_metrics/utils.py
+++ b/src/article_metrics/utils.py
@@ -187,7 +187,7 @@ def create_or_update(Model, orig_data, key_list=None, create=True, update=True, 
     key_list = subdict(data, key_list)
     try:
         # try and find an entry of Model using the key fields in the given data
-        ensure(keys, "refusing to fetch %s with empty keys: %s" % (str(Model), key_list))
+        ensure(key_list, "refusing to fetch %s with empty keys: %s" % (str(Model), key_list))
         inst = Model.objects.get(**key_list)
         # object exists, otherwise DoesNotExist would have been raised
 


### PR DESCRIPTION
responsible for this: `article_metrics.models.MultipleObjectsReturned: get() returned more than one Article -- it returned 6522!"}`

although precisely *how*, I don't know, because `models.Article.objects.get(**{})` gives you `DoesNotExist: Article matching query does not exist.` sqlite vs psql thing?