### PR TITLE
data migration before adding new db constraint

### DIFF
--- a/src/metrics/migrations/0002_auto_20180723_0620.py
+++ b/src/metrics/migrations/0002_auto_20180723_0620.py
@@ -4,7 +4,6 @@ from __future__ import unicode_literals
 
 from django.db import migrations, models
 
-
 class Migration(migrations.Migration):
 
     dependencies = [
@@ -12,6 +11,7 @@ class Migration(migrations.Migration):
     ]
 
     operations = [
+        migrations.RunSQL("delete from metrics_pagecount"), # only ever run once
         migrations.AlterField(
             model_name='pagetype',
             name='name',


### PR DESCRIPTION
fyi @giorgiosironi , the other PR made it through testing but failed deployment as the db constraint couldn't be applied with the bad data.

This deletes the contents of the data in that table then applies the migration. There will be a few minutes where `0` will be returned to journal requests while I repopulate the db