### PR TITLE
Feature: replaces 'markdown2' with 'markdown'

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,7 +12,7 @@ et3==1.5.1
 google-api-python-client==1.7.4
 green==2.12.1
 kids.cache==0.0.7
-markdown2==2.3.5
+markdown==3.0.1
 newrelic==4.4.1.104
 oauth2client==4.1.3
 psycopg2==2.7.5

--- a/src/article_metrics/views.py
+++ b/src/article_metrics/views.py
@@ -1,9 +1,13 @@
 from os.path import join
 from django.conf import settings
 from annoying.decorators import render_to
+import codecs
+import markdown
 
 @render_to('metrics/index.html')
 def index(request):
+    input_file = join(settings.PROJECT_DIR, 'README.md')
+    input_file = codecs.open(input_file, 'r', encoding="utf-8")
     return {
-        'readme': open(join(settings.PROJECT_DIR, 'README.md'), 'r').read()
+        'readme': markdown.markdown(input_file.read())
     }

--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -81,8 +81,6 @@ INSTALLED_APPS = (
     'django.contrib.messages',
     'django.contrib.staticfiles',
 
-    'django_markdown2', # landing page is rendered markdown
-
     'rest_framework',
     'rest_framework_swagger', # gui for api
 

--- a/src/templates/metrics/index.html
+++ b/src/templates/metrics/index.html
@@ -1,8 +1,7 @@
 {% extends "page-base.html" %}
-{% load md2 %}
 {% block html-head %}
 {{ block.super }}
 <base target="_blank">
 {% endblock %}
 
-{% block page-body %}{{ readme|markdown }}{% endblock %}
+{% block page-body %}{{ readme|safe }}{% endblock %}


### PR DESCRIPTION
address the security vulnerability by replacing the library altogether