### PR TITLE
Feature: switches non-article view counts from 'sessions' to 'unique pageviews'

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ would yield a response similar to:
 
 ## Copyright & Licence
  
-Copyright 2016 eLife Sciences. Licensed under the [GPLv3](LICENCE.txt)
+Copyright 2016-2019 eLife Sciences. Licensed under the [GPLv3](LICENCE.txt)
 
 This program is free software: you can redistribute it and/or modify
 it under the terms of the GNU General Public License as published by

--- a/src/metrics/cmds.py
+++ b/src/metrics/cmds.py
@@ -1,7 +1,9 @@
 # django's management.command feature is troublesome to mock
 # it also encourages code to grow way out in the sticks
 # this module brings it all back locally
-
+import os, json
+from django.conf import settings
+from datetime import date
 from . import logic, models
 from article_metrics import utils
 import logging
@@ -13,3 +15,15 @@ def ingest_command(type_list):
         utils.lmap(logic.update_ptype, supported_types)
     except BaseException as err:
         LOG.exception(str(err))
+
+def update_test_fixtures():
+
+    # ga-response-events-frame2.json
+    start = date(year=2018, month=1, day=1)
+    end = date(year=2018, month=1, day=31)
+    frame_query_list = logic.build_ga_query(models.EVENT, start, end)
+    frame, query = frame_query_list[0]
+    response = logic.query_ga(models.EVENT, query)
+    path = os.path.join(settings.SRC_DIR, "metrics/tests/fixtures/ga-response-events-frame2.json")
+    json.dump(response, open(path, 'w'), indent=4)
+    print("wrote", path)

--- a/src/metrics/cmds.py
+++ b/src/metrics/cmds.py
@@ -7,12 +7,15 @@ from datetime import date
 from . import logic, models
 from article_metrics import utils
 import logging
+from functools import partial
+
 LOG = logging.getLogger(__name__)
 
-def ingest_command(type_list):
+def ingest_command(type_list, replace_cache_files=False):
     try:
         supported_types = [t for t in type_list if t in models.PAGE_TYPES] or models.PAGE_TYPES
-        utils.lmap(logic.update_ptype, supported_types)
+        update_ptype = partial(logic.update_ptype, replace_cache_files=replace_cache_files)
+        utils.lmap(update_ptype, supported_types)
     except BaseException as err:
         LOG.exception(str(err))
 

--- a/src/metrics/logic.py
+++ b/src/metrics/logic.py
@@ -200,9 +200,8 @@ def query_ga(ptype, query, results_pp=MAX_GA_RESULTS, replace_cache_files=False)
         if not replace_cache_files:
             LOG.info("(cache hit)")
             return json.load(open(dump_path, 'r'))
-        else:
-            # cache file will be replaced with results
-            pass
+        # cache file will be replaced with results
+        pass
 
     query['max_results'] = results_pp
     query['start_index'] = 1
@@ -211,10 +210,10 @@ def query_ga(ptype, query, results_pp=MAX_GA_RESULTS, replace_cache_files=False)
     while True:
         LOG.info("requesting page %s for query %s" % (page, query['filters']))
         # requests_cache + ga query service makes expiring individual urls difficult
-        #if replace_cache_files:
+        # if replace_cache_files:
         #    with requests_cache.disabled():
         #        response = ga_core.query_ga(query)
-        #else:
+        # else:
         #    response = ga_core.query_ga(query)
         response = ga_core.query_ga(query)
         results.extend(response.get('rows') or [])

--- a/src/metrics/logic.py
+++ b/src/metrics/logic.py
@@ -258,7 +258,7 @@ def build_ga_query__queries_for_frame(ptype, frame, start_date, end_date):
     query = {
         'ids': settings.GA_TABLE_ID,
         'max_results': MAX_GA_RESULTS,
-        'metrics': 'ga:sessions', # *not* pageviews
+        'metrics': 'ga:uniquePageviews', # *not* sessions, nor regular pageviews
         'dimensions': 'ga:pagePath,ga:date',
         'sort': 'ga:pagePath,ga:date',
         'include_empty_rows': False,

--- a/src/metrics/logic.py
+++ b/src/metrics/logic.py
@@ -190,14 +190,19 @@ def process_response(ptype, frame, response):
 #
 #
 
-def query_ga(ptype, query, results_pp=MAX_GA_RESULTS):
+def query_ga(ptype, query, results_pp=MAX_GA_RESULTS, replace_cache_files=False):
     ensure(is_inrange(results_pp, 1, MAX_GA_RESULTS), "`results_pp` must be an integer between 1 and %s" % MAX_GA_RESULTS)
     sd, ed = query['start_date'], query['end_date']
     LOG.info("querying GA for %ss between %s and %s" % (ptype, sd, ed))
     dump_path = ga_core.output_path(ptype, sd, ed)
+    # TODO: this settings.TESTING check is a code smell.
     if os.path.exists(dump_path) and not settings.TESTING:
-        LOG.debug("(cache hit)")
-        return json.load(open(dump_path, 'r'))
+        if not replace_cache_files:
+            LOG.info("(cache hit)")
+            return json.load(open(dump_path, 'r'))
+        else:
+            # cache file will be replaced with results
+            pass
 
     query['max_results'] = results_pp
     query['start_index'] = 1
@@ -205,6 +210,12 @@ def query_ga(ptype, query, results_pp=MAX_GA_RESULTS):
     page, results = 1, []
     while True:
         LOG.info("requesting page %s for query %s" % (page, query['filters']))
+        # requests_cache + ga query service makes expiring individual urls difficult
+        #if replace_cache_files:
+        #    with requests_cache.disabled():
+        #        response = ga_core.query_ga(query)
+        #else:
+        #    response = ga_core.query_ga(query)
         response = ga_core.query_ga(query)
         results.extend(response.get('rows') or [])
         if (results_pp * page) >= response['totalResults']:
@@ -356,11 +367,11 @@ def update_page_counts(ptype, page_counts):
 #
 #
 
-def update_ptype(ptype):
-    "glue code to query ga about a page-type and then processing and storing the results"
+def update_ptype(ptype, replace_cache_files=False):
+    "glue code to query GA about a page-type and then processing and storing the results"
     try:
         for frame, query in build_ga_query(ptype):
-            response = query_ga(ptype, query)
+            response = query_ga(ptype, query, replace_cache_files=replace_cache_files)
             normalised_rows = process_response(ptype, frame, response)
             counts = aggregate(normalised_rows)
             LOG.info("inserting/updating %s %ss" % (len(counts), ptype))

--- a/src/metrics/management/commands/ingest.py
+++ b/src/metrics/management/commands/ingest.py
@@ -9,10 +9,11 @@ class Command(BaseCommand):
 
     def add_arguments(self, parser):
         parser.add_argument('--type', nargs='+', dest='just_type', type=str, default=[])
+        parser.add_argument('--replace-cache-files', dest='replace_cache_files', action='store_const', const=True, default=False)
 
     def handle(self, *args, **options):
         try:
-            cmds.ingest_command(options['just_type'])
+            cmds.ingest_command(type_list=options['just_type'], replace_cache_files=options['replace_cache_files'])
         except BaseException as err:
             LOG.error("uncaught exception calling command 'ingest': %s" % err, extra={'cli-args': options})
             sys.exit(1)

--- a/src/metrics/management/commands/update_fixtures.py
+++ b/src/metrics/management/commands/update_fixtures.py
@@ -1,0 +1,15 @@
+import sys
+from django.core.management.base import BaseCommand
+from metrics import cmds
+import logging
+LOG = logging.getLogger(__name__)
+
+class Command(BaseCommand):
+    help = 'downloads and updates the fixtures used in testing'
+
+    def handle(self, *args, **options):
+        try:
+            cmds.update_test_fixtures()
+        except BaseException:
+            LOG.exception("uncaught exception calling command 'update_test_fixtures'")
+            sys.exit(1)

--- a/src/metrics/tests/fixtures/ga-response-events-frame2.json
+++ b/src/metrics/tests/fixtures/ga-response-events-frame2.json
@@ -13,7 +13,7 @@
         {
             "columnType": "METRIC",
             "dataType": "INTEGER",
-            "name": "ga:sessions"
+            "name": "ga:uniquePageviews"
         }
     ],
     "containsSampledData": false,
@@ -25,7 +25,7 @@
         "filters": "ga:pagePath=~^/events$,ga:pagePath=~^/events/.*$",
         "max-results": 10000,
         "metrics": [
-            "ga:sessions"
+            "ga:uniquePageviews"
         ],
         "sort": [
             "ga:pagePath",
@@ -37,8 +37,18 @@
     "rows": [
         [
             "/events",
+            "20180102",
+            "3"
+        ],
+        [
+            "/events",
+            "20180103",
+            "1"
+        ],
+        [
+            "/events",
             "20180104",
-            "2"
+            "5"
         ],
         [
             "/events",
@@ -48,37 +58,42 @@
         [
             "/events",
             "20180108",
-            "1"
+            "2"
         ],
         [
             "/events",
             "20180109",
-            "2"
+            "3"
         ],
         [
             "/events",
             "20180110",
-            "2"
+            "3"
         ],
         [
             "/events",
             "20180111",
-            "6"
+            "10"
         ],
         [
             "/events",
             "20180112",
-            "1"
-        ],
-        [
-            "/events",
-            "20180115",
             "2"
         ],
         [
             "/events",
+            "20180115",
+            "3"
+        ],
+        [
+            "/events",
             "20180116",
-            "4"
+            "7"
+        ],
+        [
+            "/events",
+            "20180117",
+            "2"
         ],
         [
             "/events",
@@ -87,18 +102,28 @@
         ],
         [
             "/events",
-            "20180123",
+            "20180119",
             "3"
         ],
         [
             "/events",
-            "20180124",
+            "20180122",
             "1"
         ],
         [
             "/events",
+            "20180123",
+            "4"
+        ],
+        [
+            "/events",
+            "20180124",
+            "6"
+        ],
+        [
+            "/events",
             "20180125",
-            "3"
+            "5"
         ],
         [
             "/events",
@@ -108,27 +133,42 @@
         [
             "/events",
             "20180129",
-            "1"
+            "9"
         ],
         [
             "/events",
             "20180130",
-            "2"
+            "5"
         ],
         [
             "/events",
             "20180131",
+            "2"
+        ],
+        [
+            "/events/2c3f1a46/ecrwednesday-webinar-alternate-career-options-for-researchers",
+            "20180102",
+            "1"
+        ],
+        [
+            "/events/2c3f1a46/ecrwednesday-webinar-alternate-career-options-for-researchers",
+            "20180104",
+            "1"
+        ],
+        [
+            "/events/2c3f1a46/ecrwednesday-webinar-alternate-career-options-for-researchers",
+            "20180109",
             "1"
         ],
         [
             "/events/2c3f1a46/ecrwednesday-webinar-alternate-career-options-for-researchers",
             "20180110",
-            "8"
+            "9"
         ],
         [
             "/events/2c3f1a46/ecrwednesday-webinar-alternate-career-options-for-researchers",
             "20180111",
-            "2"
+            "4"
         ],
         [
             "/events/2c3f1a46/ecrwednesday-webinar-alternate-career-options-for-researchers",
@@ -143,12 +183,12 @@
         [
             "/events/2c3f1a46/ecrwednesday-webinar-alternate-career-options-for-researchers",
             "20180116",
-            "4"
+            "6"
         ],
         [
             "/events/2c3f1a46/ecrwednesday-webinar-alternate-career-options-for-researchers",
             "20180117",
-            "1"
+            "4"
         ],
         [
             "/events/2c3f1a46/ecrwednesday-webinar-alternate-career-options-for-researchers",
@@ -158,6 +198,51 @@
         [
             "/events/2c3f1a46/ecrwednesday-webinar-alternate-career-options-for-researchers",
             "20180119",
+            "3"
+        ],
+        [
+            "/events/2c3f1a46/ecrwednesday-webinar-alternate-career-options-for-researchers",
+            "20180123",
+            "1"
+        ],
+        [
+            "/events/2c3f1a46/ecrwednesday-webinar-alternate-career-options-for-researchers",
+            "20180124",
+            "1"
+        ],
+        [
+            "/events/2c3f1a46/ecrwednesday-webinar-alternate-career-options-for-researchers",
+            "20180125",
+            "3"
+        ],
+        [
+            "/events/2c3f1a46/ecrwednesday-webinar-alternate-career-options-for-researchers",
+            "20180126",
+            "2"
+        ],
+        [
+            "/events/2c3f1a46/ecrwednesday-webinar-alternate-career-options-for-researchers",
+            "20180127",
+            "1"
+        ],
+        [
+            "/events/2c3f1a46/ecrwednesday-webinar-alternate-career-options-for-researchers",
+            "20180129",
+            "2"
+        ],
+        [
+            "/events/2c3f1a46/ecrwednesday-webinar-alternate-career-options-for-researchers",
+            "20180130",
+            "2"
+        ],
+        [
+            "/events/2c3f1a46/ecrwednesday-webinar-alternate-career-options-for-researchers",
+            "20180131",
+            "2"
+        ],
+        [
+            "/events/65c295a9/ecrwednesday-webinar-making-science-reproducible",
+            "20180107",
             "1"
         ],
         [
@@ -191,29 +276,54 @@
             "1"
         ],
         [
-            "/events/843d8750/reddit-ask-me-anything-prof-steven-strogatz-on-applied-mathematics",
-            "20180111",
+            "/events/7fa2430d/ecrwednesday-webinar-addressing-the-career-challenges-of-bioinformaticians",
+            "20180104",
+            "1"
+        ],
+        [
+            "/events/7fa2430d/ecrwednesday-webinar-addressing-the-career-challenges-of-bioinformaticians",
+            "20180109",
+            "1"
+        ],
+        [
+            "/events/7fa2430d/ecrwednesday-webinar-addressing-the-career-challenges-of-bioinformaticians",
+            "20180116",
+            "1"
+        ],
+        [
+            "/events/7fa2430d/ecrwednesday-webinar-addressing-the-career-challenges-of-bioinformaticians",
+            "20180119",
+            "1"
+        ],
+        [
+            "/events/7fa2430d/ecrwednesday-webinar-addressing-the-career-challenges-of-bioinformaticians",
+            "20180125",
             "1"
         ],
         [
             "/events/843d8750/reddit-ask-me-anything-prof-steven-strogatz-on-applied-mathematics",
+            "20180111",
+            "6"
+        ],
+        [
+            "/events/843d8750/reddit-ask-me-anything-prof-steven-strogatz-on-applied-mathematics",
             "20180112",
-            "245"
+            "247"
         ],
         [
             "/events/843d8750/reddit-ask-me-anything-prof-steven-strogatz-on-applied-mathematics",
             "20180113",
-            "133"
+            "134"
         ],
         [
             "/events/843d8750/reddit-ask-me-anything-prof-steven-strogatz-on-applied-mathematics",
             "20180114",
-            "87"
+            "89"
         ],
         [
             "/events/843d8750/reddit-ask-me-anything-prof-steven-strogatz-on-applied-mathematics",
             "20180115",
-            "437"
+            "446"
         ],
         [
             "/events/843d8750/reddit-ask-me-anything-prof-steven-strogatz-on-applied-mathematics",
@@ -223,7 +333,7 @@
         [
             "/events/843d8750/reddit-ask-me-anything-prof-steven-strogatz-on-applied-mathematics",
             "20180117",
-            "34"
+            "35"
         ],
         [
             "/events/843d8750/reddit-ask-me-anything-prof-steven-strogatz-on-applied-mathematics",
@@ -328,42 +438,42 @@
         [
             "/events/b6f28e5d/ecrwednesday-webinar-how-to-be-a-medic-and-a-scientist",
             "20180103",
-            "5"
+            "7"
         ],
         [
             "/events/b6f28e5d/ecrwednesday-webinar-how-to-be-a-medic-and-a-scientist",
             "20180104",
-            "11"
+            "12"
         ],
         [
             "/events/b6f28e5d/ecrwednesday-webinar-how-to-be-a-medic-and-a-scientist",
             "20180105",
-            "8"
+            "10"
         ],
         [
             "/events/b6f28e5d/ecrwednesday-webinar-how-to-be-a-medic-and-a-scientist",
             "20180106",
-            "7"
+            "8"
         ],
         [
             "/events/b6f28e5d/ecrwednesday-webinar-how-to-be-a-medic-and-a-scientist",
             "20180108",
-            "22"
+            "24"
         ],
         [
             "/events/b6f28e5d/ecrwednesday-webinar-how-to-be-a-medic-and-a-scientist",
             "20180109",
-            "17"
+            "21"
         ],
         [
             "/events/b6f28e5d/ecrwednesday-webinar-how-to-be-a-medic-and-a-scientist",
             "20180110",
-            "7"
+            "9"
         ],
         [
             "/events/b6f28e5d/ecrwednesday-webinar-how-to-be-a-medic-and-a-scientist",
             "20180111",
-            "17"
+            "19"
         ],
         [
             "/events/b6f28e5d/ecrwednesday-webinar-how-to-be-a-medic-and-a-scientist",
@@ -378,27 +488,27 @@
         [
             "/events/b6f28e5d/ecrwednesday-webinar-how-to-be-a-medic-and-a-scientist",
             "20180114",
-            "4"
+            "5"
         ],
         [
             "/events/b6f28e5d/ecrwednesday-webinar-how-to-be-a-medic-and-a-scientist",
             "20180115",
-            "12"
+            "14"
         ],
         [
             "/events/b6f28e5d/ecrwednesday-webinar-how-to-be-a-medic-and-a-scientist",
             "20180116",
-            "20"
+            "22"
         ],
         [
             "/events/b6f28e5d/ecrwednesday-webinar-how-to-be-a-medic-and-a-scientist",
             "20180117",
-            "3"
+            "5"
         ],
         [
             "/events/b6f28e5d/ecrwednesday-webinar-how-to-be-a-medic-and-a-scientist",
             "20180118",
-            "40"
+            "41"
         ],
         [
             "/events/b6f28e5d/ecrwednesday-webinar-how-to-be-a-medic-and-a-scientist",
@@ -418,27 +528,27 @@
         [
             "/events/b6f28e5d/ecrwednesday-webinar-how-to-be-a-medic-and-a-scientist",
             "20180122",
-            "4"
+            "6"
         ],
         [
             "/events/b6f28e5d/ecrwednesday-webinar-how-to-be-a-medic-and-a-scientist",
             "20180123",
-            "52"
+            "53"
         ],
         [
             "/events/b6f28e5d/ecrwednesday-webinar-how-to-be-a-medic-and-a-scientist",
             "20180124",
-            "56"
+            "60"
         ],
         [
             "/events/b6f28e5d/ecrwednesday-webinar-how-to-be-a-medic-and-a-scientist",
             "20180125",
-            "17"
+            "19"
         ],
         [
             "/events/b6f28e5d/ecrwednesday-webinar-how-to-be-a-medic-and-a-scientist",
             "20180126",
-            "4"
+            "5"
         ],
         [
             "/events/b6f28e5d/ecrwednesday-webinar-how-to-be-a-medic-and-a-scientist",
@@ -448,22 +558,22 @@
         [
             "/events/b6f28e5d/ecrwednesday-webinar-how-to-be-a-medic-and-a-scientist",
             "20180128",
-            "6"
+            "5"
         ],
         [
             "/events/b6f28e5d/ecrwednesday-webinar-how-to-be-a-medic-and-a-scientist",
             "20180129",
-            "14"
+            "18"
         ],
         [
             "/events/b6f28e5d/ecrwednesday-webinar-how-to-be-a-medic-and-a-scientist",
             "20180130",
-            "14"
+            "19"
         ],
         [
             "/events/b6f28e5d/ecrwednesday-webinar-how-to-be-a-medic-and-a-scientist",
             "20180131",
-            "33"
+            "37"
         ],
         [
             "/events/b6f28e5d/ecrwednesday-webinar-how-to-be-a-medic-and-a-scientist?lipi=urn:li:page:d_flagship3_profile_view_base_recent_activity_details_all;kOS6eQytS52hMSnInwDrew==",
@@ -478,17 +588,17 @@
         [
             "/events/c40798c3/elife-innovation-sprint-2018",
             "20180129",
-            "57"
+            "62"
         ],
         [
             "/events/c40798c3/elife-innovation-sprint-2018",
             "20180130",
-            "53"
+            "54"
         ],
         [
             "/events/c40798c3/elife-innovation-sprint-2018",
             "20180131",
-            "39"
+            "40"
         ],
         [
             "/events/c40798c3/save-the-date-for-the-elife-innovation-sprint",
@@ -498,17 +608,17 @@
         [
             "/events/c40798c3/save-the-date-for-the-elife-innovation-sprint",
             "20180103",
-            "11"
+            "12"
         ],
         [
             "/events/c40798c3/save-the-date-for-the-elife-innovation-sprint",
             "20180104",
-            "9"
+            "11"
         ],
         [
             "/events/c40798c3/save-the-date-for-the-elife-innovation-sprint",
             "20180105",
-            "7"
+            "8"
         ],
         [
             "/events/c40798c3/save-the-date-for-the-elife-innovation-sprint",
@@ -528,7 +638,7 @@
         [
             "/events/c40798c3/save-the-date-for-the-elife-innovation-sprint",
             "20180110",
-            "2"
+            "5"
         ],
         [
             "/events/c40798c3/save-the-date-for-the-elife-innovation-sprint",
@@ -538,7 +648,7 @@
         [
             "/events/c40798c3/save-the-date-for-the-elife-innovation-sprint",
             "20180112",
-            "1"
+            "2"
         ],
         [
             "/events/c40798c3/save-the-date-for-the-elife-innovation-sprint",
@@ -558,7 +668,7 @@
         [
             "/events/c40798c3/save-the-date-for-the-elife-innovation-sprint",
             "20180116",
-            "2"
+            "3"
         ],
         [
             "/events/c40798c3/save-the-date-for-the-elife-innovation-sprint",
@@ -568,7 +678,7 @@
         [
             "/events/c40798c3/save-the-date-for-the-elife-innovation-sprint",
             "20180118",
-            "2"
+            "3"
         ],
         [
             "/events/c40798c3/save-the-date-for-the-elife-innovation-sprint",
@@ -588,7 +698,7 @@
         [
             "/events/c40798c3/save-the-date-for-the-elife-innovation-sprint",
             "20180123",
-            "2"
+            "3"
         ],
         [
             "/events/c40798c3/save-the-date-for-the-elife-innovation-sprint",
@@ -598,7 +708,17 @@
         [
             "/events/c40798c3/save-the-date-for-the-elife-innovation-sprint",
             "20180125",
-            "2"
+            "4"
+        ],
+        [
+            "/events/c40798c3/save-the-date-for-the-elife-innovation-sprint",
+            "20180126",
+            "1"
+        ],
+        [
+            "/events/c40798c3/save-the-date-for-the-elife-innovation-sprint",
+            "20180129",
+            "3"
         ],
         [
             "/events/c40798c3/save-the-date-for-the-elife-innovation-sprint?mc_cid=7dce7efa97&mc_eid=[UNIQID]",
@@ -608,7 +728,7 @@
         [
             "/events/c40798c3/save-the-date-for-the-elife-innovation-sprint?mc_cid=7dce7efa97&mc_eid=[UNIQID]",
             "20180111",
-            "12"
+            "13"
         ],
         [
             "/events/c40798c3/save-the-date-for-the-elife-innovation-sprint?mc_cid=7dce7efa97&mc_eid=[UNIQID]",
@@ -623,6 +743,11 @@
         [
             "/events/c40798c3/save-the-date-for-the-elife-innovation-sprint?open-sesame=",
             "20180129",
+            "2"
+        ],
+        [
+            "/events/c40798c3/save-the-date-for-the-elife-innovation-sprint?opensesame=",
+            "20180125",
             "1"
         ],
         [
@@ -646,8 +771,9 @@
             "1"
         ]
     ],
-    "totalResults": 122,
+    "totalPages": 1,
+    "totalResults": 147,
     "totalsForAllResults": {
-        "ga:sessions": "1869"
+        "ga:uniquePageviews": "2040"
     }
 }

--- a/src/metrics/tests/test_logic.py
+++ b/src/metrics/tests/test_logic.py
@@ -140,7 +140,6 @@ class Two(base.BaseCase):
         end = date(year=2017, month=12, day=25) # non-maximum value
         frame_query_list = logic.build_ga_query(models.EVENT, start, end)
         frame, query = frame_query_list[0]
-
         self.assertEqual(query['start_date'], start)
         self.assertEqual(query['end_date'], end)
 
@@ -279,13 +278,13 @@ class Two(base.BaseCase):
 
         # list index, expected row
         expected = [
-            (8, {'views': 4, 'identifier': '', 'date': date(2018, 1, 16)}),
-            (32, {'identifier': '843d8750', 'views': 245, 'date': date(2018, 1, 12)}),
-            (35, {'views': 437, 'identifier': '843d8750', 'date': date(2018, 1, 15)}),
-            (114, {'views': 12, 'identifier': 'c40798c3', 'date': date(2018, 1, 11)})
+            (10, {'views': 7, 'identifier': '', 'date': date(2018, 1, 16)}),
+            (54, {'identifier': '843d8750', 'views': 247, 'date': date(2018, 1, 12)}),
+            (57, {'views': 446, 'identifier': '843d8750', 'date': date(2018, 1, 15)}),
+            (121, {'views': 2, 'identifier': 'c40798c3', 'date': date(2018, 1, 11)})
         ]
         for idx, expected_row in expected:
-            self.assertEqual(processed_results[idx], expected_row)
+            self.assertEqual(expected_row, processed_results[idx])
 
     @skip('no special results processors anymore')
     def test_process_response_special_processor(self):
@@ -315,11 +314,11 @@ class Two(base.BaseCase):
         apple1 = 1
         fixture['rows'][apple1] = [None, None, None] # it's a triple but quite useless (ValueError)
         apple2 = 7
-        fixture['rows'][apple2] = 'how you like them apples?' # unhandled (BaseException)
+        fixture['rows'][apple2] = 'how you like dem apples?' # unhandled (BaseException)
 
         with patch('metrics.logic.LOG') as mock:
             processed_results = logic.process_response(models.EVENT, frame, fixture) # kaboom
-            expected_results = 122 - 2 # total non-aggregated results minus bad apples
+            expected_results = 147 - 2 # total non-aggregated results minus bad apples
             self.assertEqual(len(processed_results), expected_results)
             self.assertEqual(mock.exception.call_count, 1) # one unhandled error
             self.assertEqual(mock.info.call_count, 1) # one handled error
@@ -412,10 +411,10 @@ class Three(base.BaseCase):
             with patch('metrics.logic.query_ga', return_value=fixture):
                 logic.update_ptype(models.EVENT)
 
-        self.assertEqual(models.Page.objects.count(), 11)
+        self.assertEqual(models.Page.objects.count(), 13)
         self.assertEqual(models.PageType.objects.count(), 1) # 'event'
         # not the same as len(fixture.rows) because of aggregation
-        self.assertEqual(models.PageCount.objects.count(), 115)
+        self.assertEqual(models.PageCount.objects.count(), 138)
 
 class Four(base.BaseCase):
     def setUp(self):

--- a/src/metrics/tests/test_views.py
+++ b/src/metrics/tests/test_views.py
@@ -38,25 +38,29 @@ class Two(base.BaseCase):
 
         expected = {
             'periods': [
-                {'period': '2018-01-31', 'value': 1},
-                {'period': '2018-01-30', 'value': 2},
-                {'period': '2018-01-29', 'value': 1},
+                {'period': '2018-01-31', 'value': 2},
+                {'period': '2018-01-30', 'value': 5},
+                {'period': '2018-01-29', 'value': 9},
                 {'period': '2018-01-26', 'value': 1},
-                {'period': '2018-01-25', 'value': 3},
-                {'period': '2018-01-24', 'value': 1},
-                {'period': '2018-01-23', 'value': 3},
+                {'period': '2018-01-25', 'value': 5},
+                {'period': '2018-01-24', 'value': 6},
+                {'period': '2018-01-23', 'value': 4},
+                {'period': '2018-01-22', 'value': 1},
+                {'period': '2018-01-19', 'value': 3},
                 {'period': '2018-01-18', 'value': 1},
-                {'period': '2018-01-16', 'value': 4},
-                {'period': '2018-01-15', 'value': 2},
-                {'period': '2018-01-12', 'value': 1},
-                {'period': '2018-01-11', 'value': 6},
-                {'period': '2018-01-10', 'value': 2},
-                {'period': '2018-01-09', 'value': 2},
-                {'period': '2018-01-08', 'value': 1},
+                {'period': '2018-01-17', 'value': 2},
+                {'period': '2018-01-16', 'value': 7},
+                {'period': '2018-01-15', 'value': 3},
+                {'period': '2018-01-12', 'value': 2},
+                {'period': '2018-01-11', 'value': 10},
+                {'period': '2018-01-10', 'value': 3},
+                {'period': '2018-01-09', 'value': 3},
+                {'period': '2018-01-08', 'value': 2},
                 {'period': '2018-01-05', 'value': 1},
-                {'period': '2018-01-04', 'value': 2}],
-            'totalPeriods': 17,
-            'totalValue': 34}
+                {'period': '2018-01-04', 'value': 5}],
+            'totalPeriods': 22,
+            'totalValue': 79}
+
         self.assertEqual(resp.json(), expected)
 
     def test_request_month_periods(self):
@@ -65,10 +69,10 @@ class Two(base.BaseCase):
         self.assertEqual(resp.status_code, 200)
         expected = {
             'periods': [
-                {'period': '2018-01', 'value': 34},
+                {'period': '2018-01', 'value': 79},
             ],
             'totalPeriods': 1,
-            'totalValue': 34
+            'totalValue': 79
         }
         self.assertEqual(resp.json(), expected)
 

--- a/update-fixtures.sh
+++ b/update-fixtures.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+# updates test fixtures
+set -e
+
+# non-article metrics
+

--- a/update-fixtures.sh
+++ b/update-fixtures.sh
@@ -3,4 +3,5 @@
 set -e
 
 # non-article metrics
-
+source venv/bin/activate
+./src/manage.py update_fixtures


### PR DESCRIPTION
* switches non-article query to `ga:uniquePageviews`
* adds a cmd to update fixtures
* updated test fixtures
* updated tests with new values
* new parameter to non-article 'ingest' command: `--replace-cached-files` that will skip reading cache files and overwrite cache file response with new results