### PR TITLE
Feature: adds the 'clear-expired-requests-cache.sh' script

### DIFF
--- a/clear-expired-requests-cache.sh
+++ b/clear-expired-requests-cache.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+# removes expired entries from the requests_cache db, shrinks db 
+set -e
+source venv/bin/activate
+
+# clear expired entries
+output_path=$(echo 'from article_metrics import handler
+print(handler.clear_expired())' | ./src/manage.py shell)
+
+# call VACUUM on the sqlite db to shrink it
+du -sh "$output_path"
+sqlite3 "$output_path" -line "VACUUM"
+du -sh "$output_path"

--- a/src/article_metrics/handler.py
+++ b/src/article_metrics/handler.py
@@ -18,7 +18,12 @@ if not settings.TESTING:
         'expire_after': timedelta(hours=24 * settings.CACHE_EXPIRY)
     })
 
+def clear_expired():
+    requests_cache.core.remove_expired_responses()
+    return(join(settings.OUTPUT_PATH, 'db.sqlite3'))
+
 def clear_cache():
+    # completely empties the requests-cache database, probably not what you intended
     requests_cache.clear()
 
 LOG = logging.getLogger('debugger') # ! logs to a different file at a finer level


### PR DESCRIPTION
* adds a script that can be called by a cronjob to remove old entries in caching db
* shrinks caching db afterwards

output is similar to:

```bash
$ ./clear-expired-requests-cache.sh 
1.4G	/home/luke/dev/python/elife-metrics/output/db.sqlite3
8.0K	/home/luke/dev/python/elife-metrics/output/db.sqlite3
```

fyi @giorgiosironi 