### PR TITLE
elife_v6.py, fixes parsing of GA results.

### DIFF
--- a/src/article_metrics/ga_metrics/elife_v6.py
+++ b/src/article_metrics/ga_metrics/elife_v6.py
@@ -48,7 +48,11 @@ def path_counts_query(table_id, from_date, to_date):
 # ...python *does* support {n,m} though, so we can filter bad article IDs in post
 # lsh@2021-11-30: still true.
 # parse the article ID from a path that may include an optional '/executable'.
-REGEX = r"/articles/(?P<artid>\d{1,5})"
+# lsh@2023-02-17: msid length increasing from max 5 digits to max 6 digits, however
+# this is a bad regex. it's been matching against "/articles/1234567890" and counting it as "/articles/12345"
+#REGEX = r"/articles/(?P<artid>\d{1,5})"
+# we now want 1-6 article digits, followed by the end of the line ($) OR url parameters, an anchor or a slash '/'
+REGEX = r"/articles/((?P<artid>\d{1,6})($|[?&#/]{1}){1})"
 PATH_RE = re.compile(REGEX, re.IGNORECASE)
 
 def path_count(pair):

--- a/src/article_metrics/tests/test_ga_query.py
+++ b/src/article_metrics/tests/test_ga_query.py
@@ -177,8 +177,13 @@ class V6(base.SimpleBaseCase):
             with patch('article_metrics.ga_metrics.core.output_path', return_value=fixture_path):
                 ga_table_id = '0xdeadbeef'
                 results = core.article_views(ga_table_id, from_dt, to_dt, cached=False, only_cached=False)
-                expected_num_results = 11738
-                expected_total = Counter(full=712582, abstract=0, digest=0)
+                # lsh@2023-02-17: regular expression changed. msids now go to 6 digits and anything longer is excluded.
+                # "/articles/058355" is now being counted
+                # "/articles/5708990" is now being excluded and not counted as "570899"
+                #expected_num_results = 11738
+                #expected_total = Counter(full=712582, abstract=0, digest=0)
+                expected_num_results = 11739
+                expected_total = Counter(full=712581, abstract=0, digest=0)
 
                 # representative sample of `/article` and `/article/executable`, /article?foo=...
                 expected_sample = [


### PR DESCRIPTION
* 6 digit msids now counted.
* fixes bug where longer msids were being counted but truncated. for example, results for /articles/123456 would have been counted against article 12345.