### PR TITLE
import-metrics, add timing information to the scrapes

### DIFF
--- a/src/article_metrics/management/commands/import_metrics.py
+++ b/src/article_metrics/management/commands/import_metrics.py
@@ -7,7 +7,29 @@ from article_metrics import logic, models
 from metrics import logic as na_logic # non-article logic
 import logging
 
-LOG = logging.getLogger('debugger')
+DEBUG_LOG = logging.getLogger('debugger')
+LOG = logging.getLogger(__name__)
+
+def timeit(label):
+    def wrap1(fn):
+        def wrap2(*args, **kwargs):
+            start = time.time()
+            LOG.info("timing for import_metrics %r started" % label)
+            try:
+                retval = fn(*args, **kwargs)
+            except BaseException as be:
+                end = time.time()
+                diff_secs = round(end - start, 2)
+                # "timing for import_metrics 'crossref-citations' (failed, KeyboardInterrupt): 58 seconds"
+                LOG.info("timing for import_metrics %r (failed, %s): %d seconds" % (label, type(be).__name__, diff_secs))
+                raise be
+            end = time.time()
+            diff_secs = round(end - start, 2)
+            # "timing for import_metrics 'crossref-citations': 58 seconds"
+            LOG.info("timing for import_metrics %r: %d seconds" % (label, diff_secs))
+            return retval
+        return wrap2
+    return wrap1
 
 class Command(BaseCommand):
     help = 'imports all metrics from google analytics'
@@ -24,6 +46,7 @@ class Command(BaseCommand):
         # import *only* from cached results, don't try to fetch from remote
         parser.add_argument('--only-cached', dest='only_cached', action="store_true", default=False)
 
+    @timeit("import_metrics.handle")
     def handle(self, *args, **options):
         today = datetime.now()
         n_days_ago = today - timedelta(days=options['days'])
@@ -41,12 +64,12 @@ class Command(BaseCommand):
         # date ranges and caching arguments don't matter to citations right now
         # caching is feasible, but only crossref supports querying citations by date range
         sources = OrderedDict([
-            (NA_METRICS, (na_logic.update_all_ptypes,)),
-            (GA_DAILY, (logic.import_ga_metrics, 'daily', from_date, to_date, use_cached, only_cached)),
-            (GA_MONTHLY, (logic.import_ga_metrics, 'monthly', n_months_ago, to_date, use_cached, only_cached)),
-            (models.CROSSREF, (logic.import_crossref_citations,)),
-            (models.SCOPUS, (logic.import_scopus_citations,)),
-            (models.PUBMED, (logic.import_pmc_citations,)),
+            (NA_METRICS, (timeit("non-article-metrics")(na_logic.update_all_ptypes),)),
+            (GA_DAILY, (timeit("article-metrics-daily")(logic.import_ga_metrics), 'daily', from_date, to_date, use_cached, only_cached)),
+            (GA_MONTHLY, (timeit("article-metrics-monthly")(logic.import_ga_metrics), 'monthly', n_months_ago, to_date, use_cached, only_cached)),
+            (models.CROSSREF, (timeit("crossref-citations")(logic.import_crossref_citations),)),
+            (models.SCOPUS, (timeit("scopus-citations")(logic.import_scopus_citations),)),
+            (models.PUBMED, (timeit("pmc-citations")(logic.import_pmc_citations),)),
         ])
 
         try:
@@ -61,13 +84,13 @@ class Command(BaseCommand):
                     time.sleep(1)
 
                 except BaseException as err:
-                    LOG.exception("unhandled error in source %s: %s", source, err)
+                    DEBUG_LOG.exception("unhandled error in source %s: %s", source, err)
                     continue
 
             end_time = time.time()
 
             elapsed_seconds = end_time - start_time
-            LOG.info("time elapsed: %s minutes" % elapsed_seconds * 60)
+            DEBUG_LOG.info("time elapsed: %s minutes" % elapsed_seconds * 60)
             elapsed_hours = math.ceil(elapsed_seconds / 3600)
             logic.recently_updated_article_notifications(hours=elapsed_hours)
 
@@ -78,8 +101,8 @@ class Command(BaseCommand):
 
         except BaseException:
             msg = "unhandled exception calling the import-metrics command."
-            LOG.exception(msg) # capture a stacktrace
-            LOG.critical(msg) # we can't recover, this command must exit
+            DEBUG_LOG.exception(msg) # capture a stacktrace
+            DEBUG_LOG.critical(msg) # we can't recover, this command must exit
             exit(1)
 
         self.stdout.write("...done\n")

--- a/src/article_metrics/management/commands/import_metrics.py
+++ b/src/article_metrics/management/commands/import_metrics.py
@@ -46,7 +46,7 @@ class Command(BaseCommand):
         # import *only* from cached results, don't try to fetch from remote
         parser.add_argument('--only-cached', dest='only_cached', action="store_true", default=False)
 
-    @timeit("import_metrics.handle")
+    @timeit("overall")
     def handle(self, *args, **options):
         today = datetime.now()
         n_days_ago = today - timedelta(days=options['days'])
@@ -90,9 +90,8 @@ class Command(BaseCommand):
             end_time = time.time()
 
             elapsed_seconds = end_time - start_time
-            DEBUG_LOG.info("time elapsed: %s minutes" % elapsed_seconds * 60)
             elapsed_hours = math.ceil(elapsed_seconds / 3600)
-            logic.recently_updated_article_notifications(hours=elapsed_hours)
+            timeit("notifications")(logic.recently_updated_article_notifications)(hours=elapsed_hours)
 
         except KeyboardInterrupt:
             print('caught second ctrl-c')


### PR DESCRIPTION
import_metrics, adds timing information to each scrape process and to the overall scrape.

- [x] review