### PR TITLE
output path fixes

### DIFF
--- a/src/article_metrics/ga_metrics/ga4.py
+++ b/src/article_metrics/ga_metrics/ga4.py
@@ -6,9 +6,7 @@ import oauth2client.service_account
 import httplib2
 import logging
 from django.conf import settings
-from ..utils import ensure, datetime_now
-from article_metrics.utils import todt_notz
-from datetime import timedelta
+from ..utils import ensure
 
 LOG = logging.getLogger(__name__)
 
@@ -35,19 +33,9 @@ def _query_ga(query_map, num_attempts=5):
     applies exponential back-off if rate limited or when service is unavailable."""
 
     from_date, to_date = query_map['dateRanges'][0]['startDate'], query_map['dateRanges'][0]['endDate']
-    daily = from_date == to_date
 
     ensure(isinstance(from_date, str), 'startDate must be a string: %s' % query_map)
     ensure(isinstance(to_date, str), 'endDate must be a string')
-
-    # lsh@2023-07-12: hard fail if we somehow managed to generate a query that might generate partial data
-    now = datetime_now()
-    yesterday = now - timedelta(days=1)
-    to_date_obj = todt_notz(to_date)
-
-    if daily:
-        ensure(to_date_obj < now, "refusing to query GA4, query `end_date` will generate partial/empty results")
-        ensure(to_date_obj < yesterday, "refusing to query GA4, query `end_date` will generate partial/empty results")
 
     property_id = 'properties/' + settings.GA4_TABLE_ID
     query = ga_service().properties().runReport(property=property_id, body=query_map)

--- a/src/article_metrics/tests/test_ga_metrics_core.py
+++ b/src/article_metrics/tests/test_ga_metrics_core.py
@@ -102,16 +102,18 @@ def test_valid_dt_pair():
     tomorrow = now + timedelta(days=1)
     valid_cases = [
         # daily
-
-        # daily, past date, valid
+        # some distant past date
         (datetime(year=2015, month=1, day=1), datetime(year=2015, month=1, day=2)),
-        # daily, the day before yesterday, valid
+        # the day before yesterday, valid, but potentially invalid results
         (two_days_ago, two_days_ago),
+        # yesterday, valid, partial results
+        (yesterday, yesterday),
+        # today, valid, partial results
+        (now, now),
+        # daily, future date, empty results
+        (tomorrow, tomorrow),
 
         # ranges
-        # these queries can't be discarded because we do monthly queries.
-        # so, we allow them here but may truncate them or refuse to cache their results elsewhere.
-
         # a range ending the day before yesterday, valid, potentially partial results.
         (datetime(year=2015, month=1, day=1), two_days_ago),
         # a range involving today, valid, partial results
@@ -121,20 +123,10 @@ def test_valid_dt_pair():
         # a range involving a future date, valid, partial results
         (two_days_ago, tomorrow),
     ]
-    invalid_cases = [
-        # daily, today, invalid, partial results
-        (now, now),
-        # daily, yesterday, invalid, partial results
-        (yesterday, yesterday),
-        # daily, future date, valid, empty results
-        (tomorrow, tomorrow),
-    ]
     inception = datetime(year=2001, month=1, day=1)
     with mock.patch('article_metrics.ga_metrics.core.datetime_now', return_value=now):
         for case in valid_cases:
             assert core.valid_dt_pair(case, inception), "expected valid: %s" % (case,)
-        for case in invalid_cases:
-            assert not core.valid_dt_pair(case, inception), "expected invalid: %s" % (case,)
 
 def test_output_path_for_view_results(test_output_dir):
     "the output path is correctly generated for views"
@@ -213,16 +205,3 @@ def test_exponential_backoff_applied_on_rate_limit():
     query = DummyQuery(raises=503)
     with pytest.raises(AssertionError):
         core._query_ga(query, num_attempts=1)
-
-def test_hard_fail_on_invalid_date():
-    now = datetime(year=2015, month=6, day=1)
-    cases = [
-        # '2015-05-30', # two days ago, a-ok
-        '2015-05-31', # one day ago, die
-        '2015-06-01', # today, die
-        '2015-06-02', # future date, die
-    ]
-    with mock.patch('article_metrics.ga_metrics.core.datetime_now', return_value=now):
-        with pytest.raises(AssertionError):
-            for case in cases:
-                core.query_ga({'end_date': case})

--- a/src/article_metrics/tests/test_ga_metrics_ga4.py
+++ b/src/article_metrics/tests/test_ga_metrics_ga4.py
@@ -1,5 +1,3 @@
-import pytest
-from datetime import datetime
 import json
 from unittest import mock
 from article_metrics.ga_metrics import ga4
@@ -21,18 +19,3 @@ def test_query_ga():
     with mock.patch('article_metrics.ga_metrics.ga4._query_ga', return_value=fixture):
         actual = ga4.query_ga(query)
     assert expected == actual
-
-def test_query_ga_hard_fail_invalid_date():
-    now = datetime(year=2015, month=6, day=1)
-    cases = [
-        ('2015-05-31', '2015-05-31'), # yesterday, invalid, die
-        ('2015-06-01', '2015-06-01'), # today, invalid, die
-        ('2015-06-02', '2015-06-02'), # tomorrow, invalid, die
-    ]
-    query = {'dateRanges': [{'startDate': None, 'endDate': None}]}
-    with mock.patch('article_metrics.ga_metrics.ga4.datetime_now', return_value=now):
-        with pytest.raises(AssertionError):
-            for start_date, end_date in cases:
-                query['dateRanges'][0]['startDate'] = start_date
-                query['dateRanges'][0]['endDate'] = end_date
-                ga4.query_ga(query)

--- a/src/metrics/logic.py
+++ b/src/metrics/logic.py
@@ -1,9 +1,9 @@
 from . import models, history, ga3, ga4
-from article_metrics.utils import ensure, lmap, create_or_update, first, ymd, lfilter, date_today
+from article_metrics.utils import ensure, lmap, create_or_update, first, ymd, lfilter
 from article_metrics.ga_metrics import core as ga_core
 from django.db.models import Sum, F
 from django.db.models.functions import TruncMonth
-from datetime import date, timedelta
+from datetime import date
 from django.db import transaction
 import logging
 
@@ -126,16 +126,6 @@ def build_ga_query(ptype, start_date=None, end_date=None):
     start_date = start_date or earliest_date
     end_date = end_date or latest_date
     ensure(start_date <= end_date, "start date %r cannot be greater than end date %r" % (start_date, end_date))
-
-    # lsh@2023-07-12: prevent empty/partial results by not querying for the current day, or a full day in the past.
-    today = date_today()
-    yesterday = today - timedelta(days=1)
-    if end_date >= today or end_date >= yesterday:
-        if start_date == end_date:
-            LOG.warning("dropping current/future date range to avoid empty/partial results.")
-            return []
-        LOG.warning("truncating current/future 'end_date' to today - 48 hours to avoid empty/partial results.")
-        end_date = yesterday - timedelta(days=1)
 
     # only those frames that overlap our start/end dates
     frame_list = interesting_frames(start_date, end_date, frame_list)

--- a/src/metrics/tests/test_logic.py
+++ b/src/metrics/tests/test_logic.py
@@ -177,38 +177,3 @@ def test_update_ptype():
     assert models.PageType.objects.count() == 1 # 'event'
     # not the same as len(fixture.rows) because of aggregation
     assert models.PageCount.objects.count() == 138
-
-def test_build_ga_query__invalid_dates_dropped():
-    today = date(year=2015, month=6, day=1)
-    invalid_cases = [
-        # yesterday, invalid
-        (date(year=2015, month=5, day=31), date(year=2015, month=5, day=31)),
-        # today, invalid
-        (date(year=2015, month=6, day=1), date(year=2015, month=6, day=1)),
-        # tomorrow, invalid
-        (date(year=2015, month=6, day=2), date(year=2015, month=6, day=2)),
-    ]
-    with patch('metrics.logic.date_today', return_value=today):
-        for start_date, end_date in invalid_cases:
-            frame = logic.build_ga_query(models.EVENT, start_date, end_date)
-            assert frame == []
-
-def test_build_ga_query__invalid_date_ranges_truncated():
-    # start of year to today is truncated to day before yesterday
-    today = date(year=2015, month=6, day=1)
-    start_date = date(year=2015, month=1, day=1)
-    invalid_cases = [
-        # yesterday
-        date(year=2015, month=5, day=31),
-        # today
-        date(year=2015, month=6, day=1),
-        # tomorrow
-        date(year=2015, month=6, day=2),
-    ]
-    expected_end_date = date(year=2015, month=5, day=30)
-    with patch('metrics.logic.date_today', return_value=today):
-        for end_date in invalid_cases:
-            query_list = logic.build_ga_query(models.EVENT, start_date, end_date)
-            assert len(query_list) == 1 # one interesting frame
-            frame, query = query_list[0]
-            assert query['end_date'] == expected_end_date


### PR DESCRIPTION
- [x] article ranged/monthly output paths are not emitted for the current month 
- [x] revert changes to date truncation in GA queries
  - we can make requests for days or day ranges with partial results, *so long as we don't cache them on disk*
- [x] a full 48 hours must have elapsed between now and the enddate
    - I'm still seeing smaller output files
- [x] review