### PR TITLE
Crossref citation counts include combined counts for all versions of a manuscript

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,3 +23,6 @@ fetch-articles:
 
 fetch-metrics:
 	$(DOCKER_COMPOSE) exec app bash -c "python src/manage.py import_metrics"
+
+fetch-citation-counts-for-article:
+	$(DOCKER_COMPOSE) exec app bash -c "python src/manage.py fetch_citation_counts_for_article $(ARTICLE_ID)"

--- a/README.md
+++ b/README.md
@@ -127,6 +127,37 @@ docker compose exec app bash -c "python src/manage.py ingest_metrics --days 999 
 
 ------------
 
+#### Fetching Citation Counts for an Article
+For use as a debugging utility, to fetch citation counts for all versions of an article (currently Crossref only) run:
+
+```bash
+make fetch-citation-counts-for-article ARTICLE_ID="85111"
+```
+(note this does not persist the data in the database)
+
+Example output:
+```
+Article with id 85111 exists
+INFO - fetching crossref citations for 10.7554/eLife.85111
+INFO - fetching crossref citations for 10.7554/eLife.85111.1
+INFO - fetching crossref citations for 10.7554/eLife.85111.2
+INFO - fetching crossref citations for 10.7554/eLife.85111.3
+
+Citation data for 85111: [
+ {'doi': '10.7554/eLife.85111', 'num': 16, 'source': 'crossref', 'source_id': 'https://doi.org/10.7554/eLife.85111'}, 
+ {'doi': '10.7554/eLife.85111.1', 'num': 12, 'source': 'crossref', 'source_id': 'https://doi.org/10.7554/eLife.85111.1'}, 
+ {'doi': '10.7554/eLife.85111.2', 'num': 3, 'source': 'crossref', 'source_id': 'https://doi.org/10.7554/eLife.85111.2'}, 
+ {'doi': '10.7554/eLife.85111.3', 'num': 3, 'source': 'crossref', 'source_id': 'https://doi.org/10.7554/eLife.85111.3'}
+]
+
+Combined citation data for 85111: {
+ 'doi': '10.7554/eLife.85111', 
+ 'num': 34, 
+ 'source': 'crossref', 
+ 'source_id': 'https://doi.org/10.7554/eLife.85111'
+}
+```
+
 ### Legacy non-docker installation
 
 [code](https://github.com/elifesciences/elife-metrics/blob/master/install.sh)

--- a/src/article_metrics/crossref/citations.py
+++ b/src/article_metrics/crossref/citations.py
@@ -52,15 +52,31 @@ def parse(xmlbytes, doi):
         'source_id': 'https://doi.org/' + doi
     }
 
-def count_for_doi(doi):
-    return parse(fetch(doi), doi)
+def count_for_doi(doi, include_all_versions=False):
+    results = parse(fetch(doi), doi)
+
+    if not include_all_versions:
+        # Just return the results for the umbrella doi
+        return results
+
+    count_for_versions = 0
+    for version in utils.get_article_versions(utils.doi2msid(doi)):
+        v_doi = f"{doi}.{version}"
+        v_results = parse(fetch(v_doi), v_doi)
+
+        if v_results:
+            count_for_versions += v_results['num']
+
+    results['num'] += count_for_versions
+    return results
+
 
 def count_for_msid(msid):
     return count_for_doi(utils.msid2doi(msid))
 
 def count_for_qs(qs):
     for art in qs:
-        yield count_for_doi(art.doi)
+        yield count_for_doi(art.doi, include_all_versions=True)
 
 #
 #

--- a/src/article_metrics/crossref/citations.py
+++ b/src/article_metrics/crossref/citations.py
@@ -55,19 +55,17 @@ def parse(xmlbytes, doi):
 def count_for_doi(doi, include_all_versions=False):
     results = parse(fetch(doi), doi)
 
-    if not include_all_versions:
-        # Just return the results for the umbrella doi
-        return results
+    if results and include_all_versions:
+        count_for_versions = 0
+        for version in utils.get_article_versions(utils.doi2msid(doi)):
+            v_doi = f"{doi}.{version}"
+            v_results = parse(fetch(v_doi), v_doi)
 
-    count_for_versions = 0
-    for version in utils.get_article_versions(utils.doi2msid(doi)):
-        v_doi = f"{doi}.{version}"
-        v_results = parse(fetch(v_doi), v_doi)
+            if v_results:
+                count_for_versions += v_results['num']
 
-        if v_results:
-            count_for_versions += v_results['num']
+        results['num'] += count_for_versions
 
-    results['num'] += count_for_versions
     return results
 
 

--- a/src/article_metrics/management/commands/fetch_citation_counts_for_article.py
+++ b/src/article_metrics/management/commands/fetch_citation_counts_for_article.py
@@ -22,7 +22,11 @@ class Command(BaseCommand):
         results = []
 
         umbrella_doi = msid2doi(article_id)
-        results.append(count_for_doi(umbrella_doi))
+        umbrella_doi_results = count_for_doi(umbrella_doi)
+        if not umbrella_doi_results:
+            return results
+
+        results.append(umbrella_doi_results)
 
         for version in get_article_versions(article_id):
             doi = f"{msid2doi(article_id)}.{version}"

--- a/src/article_metrics/management/commands/fetch_citation_counts_for_article.py
+++ b/src/article_metrics/management/commands/fetch_citation_counts_for_article.py
@@ -1,0 +1,48 @@
+from django.core.management.base import BaseCommand
+from article_metrics.crossref.citations import count_for_doi
+from article_metrics.models import Article
+from article_metrics.utils import msid2doi, get_article_versions
+
+class Command(BaseCommand):
+    help = 'A utility to fetch citation counts for all versions of a given article'
+
+    def add_arguments(self, parser):
+        parser.add_argument('article_id', type=int, help='Article id to fetch citations for e.g. 85111')
+
+    @staticmethod
+    def get_article_by_doi(article_doi):
+        try:
+            article = Article.objects.get(doi=article_doi)
+            return article
+        except Article.DoesNotExist:
+            return None
+
+    @staticmethod
+    def get_citations_for_all_versions(article_id):
+        results = []
+
+        umbrella_doi = msid2doi(article_id)
+        results.append(count_for_doi(umbrella_doi))
+
+        for version in get_article_versions(article_id):
+            doi = f"{msid2doi(article_id)}.{version}"
+            count_data = count_for_doi(doi)
+            results.append(count_data)
+
+        return results
+
+    def handle(self, *args, **options):
+        article_id = options['article_id']
+
+        article = self.get_article_by_doi(msid2doi(article_id))
+        if not article:
+            self.stdout.write(f'Article with doi {article_id} does not exist')
+            return
+
+        self.stdout.write(f'Article with id {article_id} exists')
+
+        citation_data = self.get_citations_for_all_versions(article_id)
+        self.stdout.write(f'Citation data for {article_id}: {citation_data}')
+
+        combined_citation_data = count_for_doi(msid2doi(article_id), include_all_versions=True)
+        self.stdout.write(f'Combined citation data for {article_id}: {combined_citation_data}')

--- a/src/article_metrics/tests/fixtures/crossref-request-response-2.xml
+++ b/src/article_metrics/tests/fixtures/crossref-request-response-2.xml
@@ -1,0 +1,81 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<crossref_result version="2.0" xmlns="http://www.crossref.org/qrschema/2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/qrschema/2.0 http://www.crossref.org/qrschema/crossref_query_output2.0.xsd">
+ <query_result>
+  <head>
+   <email_address>none</email_address>
+   <doi_batch_id>none</doi_batch_id>
+  </head>
+  <body>
+   <forward_link doi="10.7554/eLife.09560.1">
+    <journal_cite fl_count="0">
+     <issn type="electronic">2041-9015</issn>
+     <journal_title>Papers from the Institute of Archaeology</journal_title>
+     <article_title>“What’s in a Name?” The Taxonomy &amp; Phylogeny of Early Homo</article_title>
+     <volume>25</volume>
+     <issue>2</issue>
+     <item_number item_number_type="article-number">12</item_number>
+     <year>2016</year>
+     <publication_type>full_text</publication_type>
+     <doi type="journal_article">10.5334/pia.499</doi>
+    </journal_cite>
+   </forward_link>
+   <forward_link doi="10.7554/eLife.09560.1">
+    <book_cite fl_count="0">
+     <isbn type="electronic">978-3-319-16999-6</isbn>
+     <volume_title>Encyclopedia of Evolutionary Psychological Science</volume_title>
+     <contributors>
+      <contributor first-author="true" sequence="first" contributor_role="author">
+       <given_name>Scott A.</given_name>
+       <surname>Williams</surname>
+      </contributor>
+     </contributors>
+     <first_page>1</first_page>
+     <year>2016</year>
+     <publication_type>full_text</publication_type>
+     <component_number>Chapter 3423-1</component_number>
+     <doi type="book_content">10.1007/978-3-319-16999-6_3423-1</doi>
+    </book_cite>
+   </forward_link>
+   <forward_link doi="10.7554/eLife.09560.1">
+    <journal_cite fl_count="0">
+     <issn type="print">00472484</issn>
+     <journal_title>Journal of Human Evolution</journal_title>
+     <journal_abbreviation>Journal of Human Evolution</journal_abbreviation>
+     <article_title>Comment on “Deliberate body disposal by hominins in the Dinaledi Chamber, Cradle of Humankind, South Africa?” [J. Hum. Evol. 96 (2016) 145–148]</article_title>
+     <contributors>
+      <contributor first-author="true" sequence="first" contributor_role="author">
+       <given_name>P.H.G.M.</given_name>
+       <surname>Dirks</surname>
+      </contributor>
+      <contributor first-author="false" sequence="additional" contributor_role="author">
+       <given_name>L.R.</given_name>
+       <surname>Berger</surname>
+      </contributor>
+      <contributor first-author="false" sequence="additional" contributor_role="author">
+       <given_name>J.</given_name>
+       <surname>Hawks</surname>
+      </contributor>
+      <contributor first-author="false" sequence="additional" contributor_role="author">
+       <given_name>P.S.</given_name>
+       <surname>Randolph-Quinney</surname>
+      </contributor>
+      <contributor first-author="false" sequence="additional" contributor_role="author">
+       <given_name>L.R.</given_name>
+       <surname>Backwell</surname>
+      </contributor>
+      <contributor first-author="false" sequence="additional" contributor_role="author">
+       <given_name>E.M.</given_name>
+       <surname>Roberts</surname>
+      </contributor>
+     </contributors>
+     <volume>96</volume>
+     <first_page>149</first_page>
+     <year>2016</year>
+     <publication_type>full_text</publication_type>
+     <doi type="journal_article">10.1016/j.jhevol.2016.04.007</doi>
+    </journal_cite>
+   </forward_link>
+  </body>
+ </query_result>
+</crossref_result>
+

--- a/src/article_metrics/tests/fixtures/crossref-request-response-3.xml
+++ b/src/article_metrics/tests/fixtures/crossref-request-response-3.xml
@@ -1,0 +1,264 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<crossref_result version="2.0" xmlns="http://www.crossref.org/qrschema/2.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://www.crossref.org/qrschema/2.0 http://www.crossref.org/qrschema/crossref_query_output2.0.xsd">
+ <query_result>
+  <head>
+   <email_address>none</email_address>
+   <doi_batch_id>none</doi_batch_id>
+  </head>
+  <body>
+   <forward_link doi="10.7554/eLife.09560.2">
+    <journal_cite fl_count="0">
+     <issn type="electronic">2041-9015</issn>
+     <journal_title>Papers from the Institute of Archaeology</journal_title>
+     <article_title>“What’s in a Name?” The Taxonomy &amp; Phylogeny of Early Homo</article_title>
+     <volume>25</volume>
+     <issue>2</issue>
+     <item_number item_number_type="article-number">12</item_number>
+     <year>2016</year>
+     <publication_type>full_text</publication_type>
+     <doi type="journal_article">10.5334/pia.499</doi>
+    </journal_cite>
+   </forward_link>
+   <forward_link doi="10.7554/eLife.09560.2">
+    <book_cite fl_count="0">
+     <isbn type="electronic">978-3-319-16999-6</isbn>
+     <volume_title>Encyclopedia of Evolutionary Psychological Science</volume_title>
+     <contributors>
+      <contributor first-author="true" sequence="first" contributor_role="author">
+       <given_name>Scott A.</given_name>
+       <surname>Williams</surname>
+      </contributor>
+     </contributors>
+     <first_page>1</first_page>
+     <year>2016</year>
+     <publication_type>full_text</publication_type>
+     <component_number>Chapter 3423-1</component_number>
+     <doi type="book_content">10.1007/978-3-319-16999-6_3423-1</doi>
+    </book_cite>
+   </forward_link>
+   <forward_link doi="10.7554/eLife.09560.2">
+    <journal_cite fl_count="0">
+     <issn type="print">00472484</issn>
+     <journal_title>Journal of Human Evolution</journal_title>
+     <journal_abbreviation>Journal of Human Evolution</journal_abbreviation>
+     <article_title>Comment on “Deliberate body disposal by hominins in the Dinaledi Chamber, Cradle of Humankind, South Africa?” [J. Hum. Evol. 96 (2016) 145–148]</article_title>
+     <contributors>
+      <contributor first-author="true" sequence="first" contributor_role="author">
+       <given_name>P.H.G.M.</given_name>
+       <surname>Dirks</surname>
+      </contributor>
+      <contributor first-author="false" sequence="additional" contributor_role="author">
+       <given_name>L.R.</given_name>
+       <surname>Berger</surname>
+      </contributor>
+      <contributor first-author="false" sequence="additional" contributor_role="author">
+       <given_name>J.</given_name>
+       <surname>Hawks</surname>
+      </contributor>
+      <contributor first-author="false" sequence="additional" contributor_role="author">
+       <given_name>P.S.</given_name>
+       <surname>Randolph-Quinney</surname>
+      </contributor>
+      <contributor first-author="false" sequence="additional" contributor_role="author">
+       <given_name>L.R.</given_name>
+       <surname>Backwell</surname>
+      </contributor>
+      <contributor first-author="false" sequence="additional" contributor_role="author">
+       <given_name>E.M.</given_name>
+       <surname>Roberts</surname>
+      </contributor>
+     </contributors>
+     <volume>96</volume>
+     <first_page>149</first_page>
+     <year>2016</year>
+     <publication_type>full_text</publication_type>
+     <doi type="journal_article">10.1016/j.jhevol.2016.04.007</doi>
+    </journal_cite>
+   </forward_link>
+   <forward_link doi="10.7554/eLife.09560.2">
+    <journal_cite fl_count="0">
+     <issn type="print">2332-8940</issn>
+     <issn type="electronic">2332-8959</issn>
+     <journal_title>Temperature</journal_title>
+     <journal_abbreviation>Temperature</journal_abbreviation>
+     <article_title>The cock, the Academy, and the best scientific journal in the world</article_title>
+     <contributors>
+      <contributor first-author="true" sequence="first" contributor_role="author">
+       <given_name>Andrej A</given_name>
+       <surname>Romanovsky</surname>
+      </contributor>
+     </contributors>
+     <volume>2</volume>
+     <issue>4</issue>
+     <first_page>435</first_page>
+     <year>2015</year>
+     <publication_type>full_text</publication_type>
+     <doi type="journal_article">10.1080/23328940.2015.1113097</doi>
+    </journal_cite>
+   </forward_link>
+   <forward_link doi="10.7554/eLife.09560.2">
+    <book_cite fl_count="0">
+     <issn type="print">1574-3489</issn>
+     <issn type="electronic">1574-3497</issn>
+     <isbn type="print">978-1-4939-3644-1</isbn>
+     <isbn type="electronic">978-1-4939-3646-5</isbn>
+     <series_title>Developments in Primatology: Progress and Prospects</series_title>
+     <volume_title>The Evolution of the Primate Hand</volume_title>
+     <contributors>
+      <contributor first-author="true" sequence="first" contributor_role="author">
+       <given_name>Erik</given_name>
+       <surname>Trinkaus</surname>
+      </contributor>
+     </contributors>
+     <first_page>545</first_page>
+     <year>2016</year>
+     <publication_type>full_text</publication_type>
+     <component_number>Chapter 19</component_number>
+     <doi type="book_content">10.1007/978-1-4939-3646-5_19</doi>
+    </book_cite>
+   </forward_link>
+   <forward_link doi="10.7554/eLife.09560.2">
+    <journal_cite fl_count="0">
+     <issn type="print">00472484</issn>
+     <journal_title>Journal of Human Evolution</journal_title>
+     <journal_abbreviation>Journal of Human Evolution</journal_abbreviation>
+     <article_title>Skull diversity in the Homo lineage and the relative position of Homo naledi</article_title>
+     <contributors>
+      <contributor first-author="true" sequence="first" contributor_role="author">
+       <given_name>Lauren</given_name>
+       <surname>Schroeder</surname>
+      </contributor>
+      <contributor first-author="false" sequence="additional" contributor_role="author">
+       <given_name>Jill E.</given_name>
+       <surname>Scott</surname>
+      </contributor>
+      <contributor first-author="false" sequence="additional" contributor_role="author">
+       <given_name>Heather M.</given_name>
+       <surname>Garvin</surname>
+      </contributor>
+      <contributor first-author="false" sequence="additional" contributor_role="author">
+       <given_name>Myra F.</given_name>
+       <surname>Laird</surname>
+      </contributor>
+      <contributor first-author="false" sequence="additional" contributor_role="author">
+       <given_name>Mana</given_name>
+       <surname>Dembo</surname>
+      </contributor>
+      <contributor first-author="false" sequence="additional" contributor_role="author">
+       <given_name>Davorka</given_name>
+       <surname>Radovčić</surname>
+      </contributor>
+      <contributor first-author="false" sequence="additional" contributor_role="author">
+       <given_name>Lee R.</given_name>
+       <surname>Berger</surname>
+      </contributor>
+      <contributor first-author="false" sequence="additional" contributor_role="author">
+       <given_name>Darryl J.</given_name>
+       <surname>de Ruiter</surname>
+      </contributor>
+      <contributor first-author="false" sequence="additional" contributor_role="author">
+       <given_name>Rebecca R.</given_name>
+       <surname>Ackermann</surname>
+      </contributor>
+     </contributors>
+     <year>2016</year>
+     <publication_type>full_text</publication_type>
+     <doi type="journal_article">10.1016/j.jhevol.2016.09.014</doi>
+    </journal_cite>
+   </forward_link>
+   <forward_link doi="10.7554/eLife.09560.2">
+    <journal_cite fl_count="0">
+     <issn type="print">00472484</issn>
+     <journal_title>Journal of Human Evolution</journal_title>
+     <journal_abbreviation>Journal of Human Evolution</journal_abbreviation>
+     <article_title>The upper limb of Homo naledi</article_title>
+     <contributors>
+      <contributor first-author="true" sequence="first" contributor_role="author">
+       <given_name>Elen M.</given_name>
+       <surname>Feuerriegel</surname>
+      </contributor>
+      <contributor first-author="false" sequence="additional" contributor_role="author">
+       <given_name>David J.</given_name>
+       <surname>Green</surname>
+      </contributor>
+      <contributor first-author="false" sequence="additional" contributor_role="author">
+       <given_name>Christopher S.</given_name>
+       <surname>Walker</surname>
+      </contributor>
+      <contributor first-author="false" sequence="additional" contributor_role="author">
+       <given_name>Peter</given_name>
+       <surname>Schmid</surname>
+      </contributor>
+      <contributor first-author="false" sequence="additional" contributor_role="author">
+       <given_name>John</given_name>
+       <surname>Hawks</surname>
+      </contributor>
+      <contributor first-author="false" sequence="additional" contributor_role="author">
+       <given_name>Lee R.</given_name>
+       <surname>Berger</surname>
+      </contributor>
+      <contributor first-author="false" sequence="additional" contributor_role="author">
+       <given_name>Steven E.</given_name>
+       <surname>Churchill</surname>
+      </contributor>
+     </contributors>
+     <year>2016</year>
+     <publication_type>full_text</publication_type>
+     <doi type="journal_article">10.1016/j.jhevol.2016.09.013</doi>
+    </journal_cite>
+   </forward_link>
+   <forward_link doi="10.7554/eLife.09560.2">
+    <journal_cite fl_count="0">
+     <issn type="electronic">2050-084X</issn>
+     <journal_title>eLife</journal_title>
+     <article_title>The many mysteries ofHomo naledi</article_title>
+     <contributors>
+      <contributor first-author="true" sequence="first" contributor_role="author">
+       <given_name>Chris</given_name>
+       <surname>Stringer</surname>
+      </contributor>
+     </contributors>
+     <volume>4</volume>
+     <year>2015</year>
+     <publication_type>full_text</publication_type>
+     <doi type="journal_article">10.7554/eLife.10627</doi>
+    </journal_cite>
+   </forward_link>
+   <forward_link doi="10.7554/eLife.09560.2">
+    <journal_cite fl_count="0">
+     <issn type="print">00928674</issn>
+     <journal_title>Cell</journal_title>
+     <journal_abbreviation>Cell</journal_abbreviation>
+     <article_title>Matters of Size</article_title>
+     <volume>163</volume>
+     <issue>5</issue>
+     <first_page>1043</first_page>
+     <year>2015</year>
+     <publication_type>full_text</publication_type>
+     <doi type="journal_article">10.1016/j.cell.2015.11.014</doi>
+    </journal_cite>
+   </forward_link>
+   <forward_link doi="10.7554/eLife.09560.2">
+    <journal_cite fl_count="0">
+     <issn type="print">0038-2353</issn>
+     <issn type="electronic">1996-7489</issn>
+     <journal_title>South African Journal of Science</journal_title>
+     <journal_abbreviation>S. Afr. J. Sci</journal_abbreviation>
+     <article_title>The possibility of lichen growth on bones of Homo naledi: Were they exposed to light?</article_title>
+     <contributors>
+      <contributor first-author="true" sequence="first" contributor_role="author">
+       <given_name>J. Francis</given_name>
+       <surname>Thackeray</surname>
+      </contributor>
+     </contributors>
+     <volume>Volume 112</volume>
+     <issue>Number 7/8</issue>
+     <year>2016</year>
+     <publication_type>full_text</publication_type>
+     <doi type="journal_article">10.17159/sajs.2016/a0167</doi>
+    </journal_cite>
+   </forward_link>
+  </body>
+ </query_result>
+</crossref_result>
+

--- a/src/article_metrics/tests/test_logic.py
+++ b/src/article_metrics/tests/test_logic.py
@@ -1,3 +1,4 @@
+import pathlib
 from unittest import mock
 from article_metrics import models, logic, utils
 from datetime import datetime
@@ -12,7 +13,7 @@ def test_import_crossref_citations():
     assert models.Article.objects.count() == 1
     assert models.Citation.objects.count() == 0
 
-    crossref_response = open(base.fixture_path("crossref-request-response.xml"), 'r').read()
+    crossref_response = pathlib.Path(base.fixture_path("crossref-request-response.xml")).read_text()
     expected_citations = 53
     with mock.patch('article_metrics.crossref.citations.fetch', side_effect=[crossref_response]):
         with mock.patch('article_metrics.utils.get_article_versions', return_value=[]):
@@ -26,9 +27,9 @@ def test_import_crossref_citations_for_multiple_versions():
     assert models.Article.objects.count() == 1
     assert models.Citation.objects.count() == 0
 
-    crossref_response_1 = open(base.fixture_path("crossref-request-response.xml"), 'r').read()
-    crossref_response_2 = open(base.fixture_path("crossref-request-response-2.xml"), 'r').read()
-    crossref_response_3 = open(base.fixture_path("crossref-request-response-3.xml"), 'r').read()
+    crossref_response_1 = pathlib.Path(base.fixture_path("crossref-request-response.xml")).read_text()
+    crossref_response_2 = pathlib.Path(base.fixture_path("crossref-request-response-2.xml")).read_text()
+    crossref_response_3 = pathlib.Path(base.fixture_path("crossref-request-response-3.xml")).read_text()
     expected_citations = 66 # 53 (umbrella) + 3 (v1) + 10 (v2)
     with mock.patch('article_metrics.crossref.citations.fetch',
                     side_effect=[crossref_response_1, crossref_response_2, crossref_response_3]):

--- a/src/article_metrics/tests/test_logic.py
+++ b/src/article_metrics/tests/test_logic.py
@@ -14,10 +14,28 @@ def test_import_crossref_citations():
 
     crossref_response = open(base.fixture_path("crossref-request-response.xml"), 'r').read()
     expected_citations = 53
-    with mock.patch('article_metrics.crossref.citations.fetch', return_value=crossref_response):
-        logic.import_crossref_citations()
-        assert models.Citation.objects.count() == 1
-        assert models.Citation.objects.get(source=models.CROSSREF).num == expected_citations
+    with mock.patch('article_metrics.crossref.citations.fetch', side_effect=[crossref_response]):
+        with mock.patch('article_metrics.utils.get_article_versions', return_value=[]):
+            logic.import_crossref_citations()
+            assert models.Citation.objects.count() == 1
+            assert models.Citation.objects.get(source=models.CROSSREF).num == expected_citations
+
+@pytest.mark.django_db
+def test_import_crossref_citations_for_multiple_versions():
+    utils.create_or_update(models.Article, {'doi': '10.7554/eLife.09560'}, ['doi'])
+    assert models.Article.objects.count() == 1
+    assert models.Citation.objects.count() == 0
+
+    crossref_response_1 = open(base.fixture_path("crossref-request-response.xml"), 'r').read()
+    crossref_response_2 = open(base.fixture_path("crossref-request-response-2.xml"), 'r').read()
+    crossref_response_3 = open(base.fixture_path("crossref-request-response-3.xml"), 'r').read()
+    expected_citations = 66 # 53 (umbrella) + 3 (v1) + 10 (v2)
+    with mock.patch('article_metrics.crossref.citations.fetch',
+                    side_effect=[crossref_response_1, crossref_response_2, crossref_response_3]):
+        with mock.patch('article_metrics.utils.get_article_versions', return_value=[1, 2]):
+            logic.import_crossref_citations()
+            assert models.Citation.objects.count() == 1
+            assert models.Citation.objects.get(source=models.CROSSREF).num == expected_citations
 
 @pytest.mark.django_db
 def test_import_scopus_citations():

--- a/src/article_metrics/utils.py
+++ b/src/article_metrics/utils.py
@@ -420,8 +420,8 @@ def get_article_versions(article_id):
         data = response.json()
         doi_version = data.get('doiVersion')
         if doi_version:
-            version = doi_version.split('.')[-1]
-            return [i for i in range(1, int(version) + 1)]
+            latest_doi_version = doi_version.split('.')[-1]
+            return list(range(1, int(latest_doi_version) + 1))
     except requests.exceptions.RequestException:
         LOG.error(f"Failed to fetch article versions for {article_id}")
 

--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -303,3 +303,5 @@ DEFAULT_AUTO_FIELD = 'django.db.models.AutoField'
 
 GA_SECRETS_LOCATION = os.path.join(PROJECT_DIR, 'client-secrets.json')
 assert os.path.exists(GA_SECRETS_LOCATION), "client-secrets.json not found. I looked here: %s" % GA_SECRETS_LOCATION
+
+LAX_URL = "https://prod--gateway.elifesciences.org/articles"


### PR DESCRIPTION
### Impact

Crossref citation totals for an article now include the sum of all counts for all discoverable versions. 

For example:

```python

# count for article 85111
# before changes ---------
citation_count = {'doi': '10.7554/eLife.85111', 'num': 16, 'source': 'crossref',
                    'source_id': 'https://doi.org/10.7554/eLife.85111'}

# we were only collecting the count for the umbrella doi

# after changes ----------
citation_count = {'doi': '10.7554/eLife.85111', 'num': 34, 'source': 'crossref',
                    'source_id': 'https://doi.org/10.7554/eLife.85111'}

# we are now collecting the count for the umbrella doi & the versions and persisting the sum
# [
#     {'doi': '10.7554/eLife.85111', 'num': 16, 'source': 'crossref', 'source_id': 'https://doi.org/10.7554/eLife.85111'},
#     {'doi': '10.7554/eLife.85111.1', 'num': 12, 'source': 'crossref', 'source_id': 'https://doi.org/10.7554/eLife.85111.1'},
#     {'doi': '10.7554/eLife.85111.2', 'num': 3, 'source': 'crossref', 'source_id': 'https://doi.org/10.7554/eLife.85111.2'},
#     {'doi': '10.7554/eLife.85111.3', 'num': 3, 'source': 'crossref', 'source_id': 'https://doi.org/10.7554/eLife.85111.3'}
# ]
```


### Changes

- Added `get_article_versions` utility which calls Lax in order to get the `doiVersion` to indicate the latest version of an article
- `count_for_doi` now supports an `include_all_versions` flag, if `True` it will now collect counts for the umbrella + all versions and the total count persisted will be a sum of them all
- This flag has been set to `True`.

### Testing

- Changes are covered by new unit tests.
- Can also use the new `fetch-citation-counts-for-article` command locally to return the citation count data to validate.
e.g.
```bash
make fetch-citation-counts-for-article ARTICLE_ID="85111"
```