### PR TITLE
security: don't include any local credentials in the docker image

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,13 +32,13 @@ Docker Compose
 
 #### 3rd Party credentials for local development
 
-The service has dependencies on the following 3rd party services:  
+The service has dependencies on the following 3rd party services:
 
 [`crossref`](https://www.crossref.org)
 [`scopus`](https://www.scopus.com/home.uri)
 [`Google Analytics`](https://developers.google.com/analytics/devguides/collection/ga4)
 
-Each of these require credentials to be set in the environment. You will need to set these up in your local environment 
+Each of these require credentials to be set in the environment. You will need to set these up in your local environment
 in order to ingest/generate metrics data locally.
 
 In the `.docker/app.cfg` file, you will need to set the following variables with real values:
@@ -51,9 +51,9 @@ apikey: <scopus api key>
 user: <crossref user>
 pass: <crossref pass>
 ```
-For Google Analytics, you will need to provide a `client_secrets.json` file in the root of the project.
+For Google Analytics, you will need to provide a `client_secrets.json` file in the `.docker` directory of the project.
 
-Example `client-secrets.json` file:
+Example `.docker/client-secrets.json` file:
 ```json
 {
   "private_key_id": "<private_key_id>",

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -59,7 +59,7 @@ services:
     - ./src:/app/src
     - ./.docker/app.cfg:/app/app.cfg
     - ./.docker/migrate.sh:/app/migrate.sh
-    - ./client-secrets.json:/app/client-secrets.json
+    - ./.docker/client-secrets.json:/app/client-secrets.json
 
 volumes:
     db_data:


### PR DESCRIPTION
Hey Sean, just a quick PR after the review of https://github.com/elifesciences/elife-metrics/pull/259 I noticed the build including the credentials file. Currently on develop branch, if you follow the README you end up with this:

```
> echo '{"private_key": "shhhh"}' > client_secrets.json

> make build
docker compose build
[+] Building 
<snip>
 => => naming to docker.io/library/elife-metrics-app                                                                                                                                                                                                  0.0s

> docker image ls
REPOSITORY                                        TAG                             IMAGE ID       CREATED          SIZE
elife-metrics-migrate                             latest                          0993eeda45fd   14 seconds ago   1.19GB
elife-metrics-app                                 latest                          135ff81fa233   14 seconds ago   1.19GB

> docker run --rm elife-metrics-app cat /app/client-secrets.json
{
  "my_secret": "shhhh...."
}
```

This just changes the location that the secret file is mounted from locally to the `.docker` directory that is already ignored, and updates the readme.