### PR TITLE
Add article_metrics_by_version endpoint

### DIFF
--- a/src/article_metrics/api_v2_logic.py
+++ b/src/article_metrics/api_v2_logic.py
@@ -10,7 +10,6 @@ import logging
 import metrics.models
 import article_metrics.crossref.citations as crossref
 from django.db import connection
-from django.http import Http404
 from django.conf import settings
 from psycopg2.extensions import AsIs
 
@@ -177,7 +176,7 @@ def citations_by_version(msid, version):
     crossref_citations = crossref.parse(crossref.fetch(doi), doi)
 
     if not crossref_citations:
-        raise Http404("article version not found")
+        return None
 
     # citations have to return zeroes for any missing sources
     return [

--- a/src/article_metrics/api_v2_logic.py
+++ b/src/article_metrics/api_v2_logic.py
@@ -8,8 +8,10 @@ from kids.cache import cache
 from django.db.models import Sum, F, Max
 import logging
 import metrics.models
-from django.conf import settings
+import article_metrics.crossref.citations as crossref
 from django.db import connection
+from django.http import Http404
+from django.conf import settings
 from psycopg2.extensions import AsIs
 
 LOG = logging.getLogger(__name__)
@@ -167,3 +169,31 @@ def summary(page, per_page, order):
     start_pos = per_page * (page - 1) # slices are 0-based
     offset = start_pos + per_page
     return len(rows), rows[start_pos:offset]
+
+
+@cache(use=TWO_MIN_CACHE)
+def citations_by_version(msid, version):
+    doi = f"{utils.msid2doi(msid)}.{version}"
+    crossref_citations = crossref.parse(crossref.fetch(doi), doi)
+
+    if not crossref_citations:
+        raise Http404("article version not found")
+
+    # citations have to return zeroes for any missing sources
+    return [
+        {
+            'service': models.CROSSREF_LABEL,
+            'uri': crossref_citations['source_id'],
+            'citations': crossref_citations['num']
+        },
+        {
+            'service': models.PUBMED_LABEL,
+            'uri': '',
+            'citations': 0
+        },
+        {
+            'service': models.SCOPUS_LABEL,
+            'uri': '',
+            'citations': 0
+        }
+    ]

--- a/src/article_metrics/api_v2_urls.py
+++ b/src/article_metrics/api_v2_urls.py
@@ -6,6 +6,8 @@ urlpatterns = ([
     # article-level metrics
     re_path(r'^ping$', views.ping, name='ping'),
     re_path(r'^article/(?P<msid>\d+)/(?P<metric>(citations|downloads|page-views))$', views.article_metrics, name='alm'),
+    re_path(r'^article/(?P<msid>\d+)/(?P<metric>(citations|downloads|page-views))/version/(?P<version>\d+)$',
+            views.article_metrics_by_version, name='alm-for-version'),
 
     re_path(r'^article/(?P<msid>\d+)/summary$', views.summary, name='article-summary'),
     # lsh@2022-03-04: disabled in favour of views.summary2. views.summary still ok for individual articles.

--- a/src/article_metrics/api_v2_urls.py
+++ b/src/article_metrics/api_v2_urls.py
@@ -6,7 +6,7 @@ urlpatterns = ([
     # article-level metrics
     re_path(r'^ping$', views.ping, name='ping'),
     re_path(r'^article/(?P<msid>\d+)/(?P<metric>(citations|downloads|page-views))$', views.article_metrics, name='alm'),
-    re_path(r'^article/(?P<msid>\d+)/(?P<metric>(citations|downloads|page-views))/version/(?P<version>\d+)$',
+    re_path(r'^article/(?P<msid>\d+)/(?P<metric>(citations))/version/(?P<version>\d+)$',
             views.article_metrics_by_version, name='alm-for-version'),
 
     re_path(r'^article/(?P<msid>\d+)/summary$', views.summary, name='article-summary'),

--- a/src/article_metrics/api_v2_views.py
+++ b/src/article_metrics/api_v2_views.py
@@ -20,7 +20,7 @@ LOG = logging.getLogger(__name__)
 
 PROFILING = False
 
-ctype_idx = {
+CTYPE_IDX = {
     'citations': 'application/vnd.elife.metric-citations+json;version=1',
     'downloads': 'application/vnd.elife.metric-time-period+json;version=1',
     'page-views': 'application/vnd.elife.metric-time-period+json;version=1',
@@ -156,7 +156,7 @@ def article_metrics(request, msid, metric):
         payload = logic.pad_citations(payload) if metric == 'citations' else payload
 
         # respond
-        return Response(payload, content_type=ctype_idx[metric])
+        return Response(payload, content_type=CTYPE_IDX[metric])
 
     except Http404:
         raise # Article DNE, handled, ignore
@@ -248,10 +248,12 @@ def article_metrics_by_version(request, msid, metric, version):
             raise ValidationError("only 'citations' are currently supported for versioned article metrics")
 
         get_object_or_404(models.Article, doi=msid2doi(msid))
-        payload = logic.citations_by_version(msid, version)
+        payload = logic.citations_by_version(msid, version) # pylint: disable=E1111
 
-        return Response(payload, content_type=ctype_idx[metric])
+        if not payload:
+            raise Http404("article version does not exist")
 
+        return Response(payload, content_type=CTYPE_IDX[metric])
     except Http404:
         raise # Article DNE, handled, ignore
 

--- a/src/article_metrics/tests/fixtures/crossref-request-response-for-56789.1.xml
+++ b/src/article_metrics/tests/fixtures/crossref-request-response-for-56789.1.xml
@@ -1,0 +1,84 @@
+<?xml version='1.0' encoding='UTF-8'?>
+<crossref_result version="2.0" xmlns="http://www.crossref.org/qrschema/2.0"
+                 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+                 xsi:schemaLocation="http://www.crossref.org/qrschema/2.0 http://www.crossref.org/qrschema/crossref_query_output2.0.xsd">
+    <query_result>
+        <head>
+            <email_address>none</email_address>
+            <doi_batch_id>none</doi_batch_id>
+        </head>
+        <body>
+        <forward_link doi="10.7554/eLife.56789.1">
+            <journal_cite fl_count="0">
+                <issn type="electronic">2041-9015</issn>
+                <journal_title>Papers from the Institute of Archaeology</journal_title>
+                <article_title>“What’s in a Name?” The Taxonomy &amp; Phylogeny of Early Homo</article_title>
+                <volume>25</volume>
+                <issue>2</issue>
+                <item_number item_number_type="article-number">12</item_number>
+                <year>2016</year>
+                <publication_type>full_text</publication_type>
+                <doi type="journal_article">10.5334/pia.499</doi>
+            </journal_cite>
+        </forward_link>
+        <forward_link doi="10.7554/eLife.56789.1">
+            <book_cite fl_count="0">
+                <isbn type="electronic">978-3-319-16999-6</isbn>
+                <volume_title>Encyclopedia of Evolutionary Psychological Science</volume_title>
+                <contributors>
+                    <contributor first-author="true" sequence="first" contributor_role="author">
+                        <given_name>Scott A.</given_name>
+                        <surname>Williams</surname>
+                    </contributor>
+                </contributors>
+                <first_page>1</first_page>
+                <year>2016</year>
+                <publication_type>full_text</publication_type>
+                <component_number>Chapter 3423-1</component_number>
+                <doi type="book_content">10.1007/978-3-319-16999-6_3423-1</doi>
+            </book_cite>
+        </forward_link>
+        <forward_link doi="10.7554/eLife.56789.1">
+            <journal_cite fl_count="0">
+                <issn type="print">00472484</issn>
+                <journal_title>Journal of Human Evolution</journal_title>
+                <journal_abbreviation>Journal of Human Evolution</journal_abbreviation>
+                <article_title>Comment on “Deliberate body disposal by hominins in the Dinaledi Chamber, Cradle of
+                    Humankind, South Africa?” [J. Hum. Evol. 96 (2016) 145–148]
+                </article_title>
+                <contributors>
+                    <contributor first-author="true" sequence="first" contributor_role="author">
+                        <given_name>P.H.G.M.</given_name>
+                        <surname>Dirks</surname>
+                    </contributor>
+                    <contributor first-author="false" sequence="additional" contributor_role="author">
+                        <given_name>L.R.</given_name>
+                        <surname>Berger</surname>
+                    </contributor>
+                    <contributor first-author="false" sequence="additional" contributor_role="author">
+                        <given_name>J.</given_name>
+                        <surname>Hawks</surname>
+                    </contributor>
+                    <contributor first-author="false" sequence="additional" contributor_role="author">
+                        <given_name>P.S.</given_name>
+                        <surname>Randolph-Quinney</surname>
+                    </contributor>
+                    <contributor first-author="false" sequence="additional" contributor_role="author">
+                        <given_name>L.R.</given_name>
+                        <surname>Backwell</surname>
+                    </contributor>
+                    <contributor first-author="false" sequence="additional" contributor_role="author">
+                        <given_name>E.M.</given_name>
+                        <surname>Roberts</surname>
+                    </contributor>
+                </contributors>
+                <volume>96</volume>
+                <first_page>149</first_page>
+                <year>2016</year>
+                <publication_type>full_text</publication_type>
+                <doi type="journal_article">10.1016/j.jhevol.2016.04.007</doi>
+            </journal_cite>
+        </forward_link>
+        </body>
+    </query_result>
+</crossref_result>


### PR DESCRIPTION
### Impact

You can now query version specific Crossref citation metrics for a specific doi version e.g. `10.7554/eLife.85111.3`


### Changes

**This does not affect any existing endpoints, the new functionality is isolated to the new endpoint.**

- Added new endpoint for version specific metrics. `/api/v2/article/<article_id>/citations/version/<version>`
- The response data schema is the same as the existing `/api/v2/article/<article_id>/<metric>` endpoint
- This currently only supports `citations` metric
- This currently only supports Crossref citations
- As the data is calculated on demand you will be able to query citations for any version without having to have had to pre ingest anything
- There is a 2 minute cache on the 3rd party calls made in this endpoints handler

### Testing

- Changes are covered by new unit tests.
- You can use the new endpoint locally by selecting an article id and version e.g. http://127.0.0.1:8000/api/v2/article/85111/citations/version/1 

example response:

```
GET http://127.0.0.1:8000/api/v2/article/85111/citations/version/1
```
```json
[
    {
        "service": "Crossref",
        "uri": "https://doi.org/10.7554/eLife.85111.1",
        "citations": 12
    },
    {
        "service": "PubMed Central",
        "uri": "",
        "citations": 0
    },
    {
        "service": "Scopus",
        "uri": "",
        "citations": 0
    }
]
```

- If an invalid `version` is provided you get a `404` and the following response:
```
GET http://127.0.0.1:8000/api/v2/article/85111/citations/version/9
```
```json
{
    "detail": "article version not found"
}
```
