### PR TITLE
Fixed Docker Compose postgres healthcheck

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -5,7 +5,7 @@ services:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: password
     healthcheck:
-      test: pg_isready -d db_prod
+      test: pg_isready -U postgres -d postgres
       interval: 10s
       timeout: 3s
       retries: 3


### PR DESCRIPTION
It would keep complaining that the user `root` doesn't exist. Then that the database `db_prod` doesn't exist. That fixes it by specifying the user and db that we actually use.