### PR TITLE
Fixed article id not passed to fetch-metrics by make target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ fetch-articles:
 
 fetch-metrics:
 	$(DOCKER_COMPOSE) exec app bash -c \
-		"python src/manage.py import_metrics --source=$(SOURCE)"
+		"python src/manage.py import_metrics --source=$(SOURCE) --article-id=$(ARTICLE_ID)"
 
 fetch-citation-counts-for-article:
 	$(DOCKER_COMPOSE) exec app bash -c "python src/manage.py fetch_citation_counts_for_article $(ARTICLE_ID)"


### PR DESCRIPTION
Follow up to #299

To make the following command filter by article id:

```bash
make fetch-metrics SOURCE=crossref ARTICLE_ID="85111"
```